### PR TITLE
sorted .list

### DIFF
--- a/src/borgstore/backends/_base.py
+++ b/src/borgstore/backends/_base.py
@@ -99,4 +99,6 @@ class BackendBase(ABC):
 
         Does not yield TMP_SUFFIX items - usually they are either not finished
         uploading or they are leftover crap from aborted uploads.
+
+        The yielded ItemInfos are sorted alphabetically by name.
         """

--- a/src/borgstore/backends/posixfs.py
+++ b/src/borgstore/backends/posixfs.py
@@ -163,6 +163,7 @@ class PosixFS(BackendBase):
                         pass
                     else:
                         is_dir = stat.S_ISDIR(st.st_mode)
-                        # for a directory, we return size == 0 if there is nothing inside
-                        size = st.st_nlink - 2 if is_dir else st.st_size
+                        # sadly, there is no reliable(!) st_nlink, thus we can't return size=0 for empty dirs.
+                        # on macOS 13, it worked, on Linux (github CI), it didn't.
+                        size = 1 if is_dir else st.st_size
                         yield ItemInfo(name=p.name, exists=True, size=size, directory=is_dir)

--- a/src/borgstore/mstore.py
+++ b/src/borgstore/mstore.py
@@ -195,6 +195,7 @@ class MStore:
                 pass  # ignore it, if it is not present in this store
 
     def list(self, name: str, deleted: bool = False) -> Iterator[ItemInfo]:
+        # when using multiple stores, the results yielded might be only partially sorted.
         seen = set()
         for store in self.stores:
             for item_info in store.list(name, deleted=deleted):

--- a/src/borgstore/store.py
+++ b/src/borgstore/store.py
@@ -151,6 +151,8 @@ class Store:
 
         If deleted is True and soft deleted items are encountered, they are yielded
         as if they were not deleted. Otherwise, they are ignored.
+
+        backend.list giving us sorted names implies store.list is also sorted, if all items are stored on same level.
         """
         # as the backend.list method only supports non-recursive listing and
         # also returns directories/namespaces we introduced for nesting, we do the
@@ -158,8 +160,10 @@ class Store:
         for info in self.backend.list(name):
             if info.directory:
                 # note: we only expect subdirectories from key nesting, but not namespaces nested into each other.
-                subdir_name = (name + "/" + info.name) if name else info.name
-                yield from self.list(subdir_name, deleted=deleted)
+                if info.size > 0:
+                    # if backend returns info.size == 0 for a directory, it indicates that there is nothing inside it.
+                    subdir_name = (name + "/" + info.name) if name else info.name
+                    yield from self.list(subdir_name, deleted=deleted)
             else:
                 is_deleted = info.name.endswith(DEL_SUFFIX)
                 if deleted and is_deleted:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,9 +13,14 @@ def lkey(k: int) -> str:
     return k.to_bytes(4, "little").hex()
 
 
-def list_store_names(store, name: str, deleted: bool = False):
+def list_store_names_sorted(store, name: str, deleted: bool = False):
     # Store helper for tests only interested in the **names** of directory members
     return sorted(info.name for info in store.list(name, deleted=deleted))
+
+
+def list_store_names(store, name: str, deleted: bool = False):
+    # Store helper for tests only interested in the **names** of directory members
+    return list(info.name for info in store.list(name, deleted=deleted))
 
 
 def list_names(backend, name: str):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -207,7 +207,9 @@ def test_list(tested_backends, request):
         assert len(items) == 3
         assert ItemInfo(name=k0, exists=True, size=len(v0), directory=False) in items
         assert ItemInfo(name=k1, exists=True, size=len(v1), directory=False) in items
-        assert ItemInfo(name="dir", exists=True, size=0, directory=True) in items
+        # currently, all backends return size==1 for directories as they can't reliably signal
+        # an empty directory via size==0.
+        assert ItemInfo(name="dir", exists=True, size=1, directory=True) in items
 
         items = list(backend.list("dir"))
         assert items == []

--- a/tests/test_mstore.py
+++ b/tests/test_mstore.py
@@ -3,7 +3,7 @@ Testing for high-level MStore API.
 """
 import pytest
 
-from . import key, lkey, list_store_names
+from . import key, lkey, list_store_names, list_store_names_sorted
 
 from borgstore.backends.errors import ObjectNotFound
 from borgstore.store import Store
@@ -145,7 +145,7 @@ def test_load_store_list_redundancy(mstore_mirror_created):
             k, v = lkey(i), str(i).encode()
             assert mstore.load(k) == v
         # also check if list still works ok:
-        assert list_store_names(mstore, "") == sorted([lkey(i) for i in range(1024)])
+        assert list_store_names_sorted(mstore, "") == sorted([lkey(i) for i in range(1024)])
         # now delete some values also from the other side of the mirror:
         for i in 0, 23, 42, 1001:
             mstore.stores[1].delete(lkey(i))


### PR DESCRIPTION
backend.list:
the flat directory contents list must be sorted by name.

store.list:
if all items are stored on same level, the above implies that the recursion result list is also sorted.

mstore.list:
for some cases, like a healthy mirroring store setup, result list will be fully sorted.

but for jbod-like setups, result is only partially sorted.

but in any case, order is stable and not random.