### PR TITLE
remove cryptography requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 license = {text="BSD"}
 requires-python = ">=3.9"
 dependencies = [
-    "cryptography < 43.0.0",  # using a more recent version triggers annoying warnings with paramiko
     "paramiko",
 ]
 


### PR DESCRIPTION
the warnings issue was fixed in paramiko 3.3.2 and 3.4.1, thus we can just let paramiko pull in whatever cryptography version it wants.