### PR TITLE
github CI: run most stuff on ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
       fail-fast: true
       matrix:
         include:
-            - os: ubuntu-22.04
+            - os: ubuntu-24.04
               python-version: '3.11'
               toxenv: flake8
-            - os: ubuntu-22.04
+            - os: ubuntu-24.04
               python-version: '3.11'
               toxenv: mypy
             - os: ubuntu-22.04
@@ -43,7 +43,7 @@ jobs:
             - os: ubuntu-22.04
               python-version: '3.10'
               toxenv: py310
-            - os: ubuntu-22.04
+            - os: ubuntu-24.04
               python-version: '3.11'
               toxenv: py311
             - os: ubuntu-24.04


### PR DESCRIPTION
Only keep the python 3.9/3.10 testing on 22.04,
so we can see if there is any ubuntu version
specific difference in test behaviour.