### PR TITLE
rclone backend: fix hang on termination

### DIFF
--- a/src/borgstore/backends/rclone.py
+++ b/src/borgstore/backends/rclone.py
@@ -112,7 +112,7 @@ class Rclone(BackendBase):
                 if not line:
                     break  # Process has finished
 
-        thread = threading.Thread(target=discard)
+        thread = threading.Thread(target=discard, daemon=True)
         thread.start()
 
     def close(self):


### PR DESCRIPTION
Before this change the rclone backend was creating a non daemon thread
which was hanging borgstore when it quit without closing the backend.

This patch changes the thread into a daemon thread which won't stop
the program from exiting when the thread is running.

Fixes #54
