### PR TITLE
move types-requests to tox.ini

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ requires-python = ">=3.9"
 dependencies = [
     "paramiko >= 1.9.1",  # 1.9.1+ supports multiple IdentityKey entries in .ssh/config
     "requests >= 2.25.1",
-    "types-requests >= 2.25.1",
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -20,5 +20,6 @@ commands = flake8 src
 changedir =
 deps =
     mypy
-    types-paramiko
+    types-paramiko >= 1.9.1
+    types-requests >= 2.25.1
 commands = mypy


### PR DESCRIPTION
this is only required for mypy while developing borgstore, but not for production installs.