### PR TITLE
backend.create: only reject non-empty storage, see #57

### DIFF
--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -324,6 +324,9 @@ def test_load_partial(tested_backends, request):
 
 def test_already_exists(tested_backends, request):
     backend = get_backend_from_fixture(tested_backends, request)
+    with backend as _backend:
+        _backend.store("key", b"value")  # make the backend "not empty"
+    # the backend must reject (re-)creation if there is already something at that place:
     with pytest.raises(BackendAlreadyExists):
         backend.create()
 


### PR DESCRIPTION
we shouldn't check just for the base directory and reject if it exists, that is troublesome for cloud storages.

also, it is not really a problem if we just use an empty filesystem or sftp directory - we should only reject if there is stuff inside.