### PR TITLE
backends.sftp: fix _mkdir edge case

### DIFF
--- a/src/borgstore/backends/sftp.py
+++ b/src/borgstore/backends/sftp.py
@@ -154,8 +154,10 @@ class Sftp(BackendBase):
                     pass
         try:
             self.client.mkdir(str(p))
+        except FileNotFoundError:
+            raise  # parents == False and the parent dir is missing.
         except OSError:
-            # maybe already existed?
+            # maybe p already existed?
             if not exist_ok:
                 raise
 


### PR DESCRIPTION
when a parent dir of the path is missing, we must propagate FileNotFoundError and not suppress it in the "except OSError" block if exist_ok is True.