### PR TITLE
rclone backend: don't error on create if source directory is empty

### DIFF
--- a/src/borgstore/backends/rclone.py
+++ b/src/borgstore/backends/rclone.py
@@ -169,9 +169,11 @@ class Rclone(BackendBase):
         if self.process:
             raise BackendMustNotBeOpen()
         with self:
-            info = self.info("")
-            if info.exists:
-                raise BackendAlreadyExists(f"rclone storage base path already exists: {self.fs}")
+            try:
+                if any(self.list("")):
+                    raise BackendAlreadyExists(f"rclone storage base path exists and isn't empty: {self.fs}")
+            except ObjectNotFound:
+                pass
             self.mkdir("")
 
     def destroy(self):


### PR DESCRIPTION
Before this change rclone would raise the error

    BackendAlreadyExists: rclone storage base path already exists

On an s3 bucket which had been created but was empty.

The unit tests have been updated to allow this.

Follow up to #59