### PR TITLE
make sftp backend optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,12 @@ classifiers = [
 license = {text="BSD"}
 requires-python = ">=3.9"
 dependencies = [
-    "paramiko >= 1.9.1",  # 1.9.1+ supports multiple IdentityKey entries in .ssh/config
     "requests >= 2.25.1",
+]
+
+[project.optional-dependencies]
+sftp = [
+    "paramiko >= 1.9.1",  # 1.9.1+ supports multiple IdentityKey entries in .ssh/config
 ]
 
 [project.urls]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -137,6 +137,7 @@ def test_file_url(url, path):
     assert backend.base_path == Path(path).absolute()
 
 
+@pytest.mark.skipif(not sftp_is_available, reason="SFTP is not available")
 @pytest.mark.parametrize(
     "url,username,hostname,port,path",
     [


### PR DESCRIPTION
See issue #74.

### no sftp backend, no need for paramiko, cryptography, rust, etc.

```
pip install borgstore
```

### sftp backend available, but needs paramiko + dependencies.

```
pip install "borgstore[sftp]"
```

note: rclone backend also supports sftp remotes.