### PR TITLE
sftp: by default, use a relative path, hack for abs path

### DIFF
--- a/src/borgstore/backends/sftp.py
+++ b/src/borgstore/backends/sftp.py
@@ -20,13 +20,18 @@ from ..constants import TMP_SUFFIX
 
 
 def get_sftp_backend(url):
-    # sftp://username@hostname:22/var/backups/borgstore/second
-    # note: username and port optional, host must be a hostname (not IP), must give path
+    # sftp://username@hostname:22/path
+    # note:
+    # - username and port optional
+    # - host must be a hostname (not IP)
+    # - must give a path, default is a relative path (usually relative to user's home dir -
+    #   this is so that the sftp server admin can move stuff around without the user needing to know).
+    # - giving an absolute path is also possible: sftp://username@hostname:22//home/username/borgstore
     sftp_regex = r"""
         sftp://
         ((?P<username>[^@]+)@)?
-        (?P<hostname>([^:/]+))(?::(?P<port>\d+))?
-        (?P<path>(/.*))
+        (?P<hostname>([^:/]+))(?::(?P<port>\d+))?/  # slash as separator, not part of the path
+        (?P<path>(.+))  # path may or may not start with a slash, must not be empty
     """
     if paramiko is not None:
         m = re.match(sftp_regex, url, re.VERBOSE)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -41,7 +41,9 @@ def posixfs_backend_created(tmp_path):
 
 
 def get_sftp_test_backend():
-    # export BORGSTORE_TEST_SFTP_URL="sftp://user@host:port/home/user/borgstore/temp-store"
+    # export BORGSTORE_TEST_SFTP_URL="sftp://user@host:port/borgstore/temp-store"
+    # please note that the path is relative, usually to the user's home directory on the server.
+    # giving an absolute path: "sftp://user@host:port//home/user/borgstore/temp-store"
     # needs an authorized key loaded into the ssh agent. pytest works, tox doesn't.
     url = os.environ.get("BORGSTORE_TEST_SFTP_URL")
     if url:
@@ -164,9 +166,12 @@ def test_invalid_or_remote_file_url(url):
 @pytest.mark.parametrize(
     "url,username,hostname,port,path",
     [
-        ("sftp://username@hostname:2222/some/path", "username", "hostname", 2222, "/some/path"),
-        ("sftp://username@hostname/some/path", "username", "hostname", 0, "/some/path"),
-        ("sftp://hostname/some/path", None, "hostname", 0, "/some/path"),
+        ("sftp://username@hostname:2222/rel/path", "username", "hostname", 2222, "rel/path"),
+        ("sftp://username@hostname/rel/path", "username", "hostname", 0, "rel/path"),
+        ("sftp://hostname/rel/path", None, "hostname", 0, "rel/path"),
+        ("sftp://username@hostname:2222//abs/path", "username", "hostname", 2222, "/abs/path"),
+        ("sftp://username@hostname//abs/path", "username", "hostname", 0, "/abs/path"),
+        ("sftp://hostname//abs/path", None, "hostname", 0, "/abs/path"),
     ],
 )
 def test_sftp_url(url, username, hostname, port, path):


### PR DESCRIPTION
sftp://username@hostname:22/borgstore - relative (usually to home dir) sftp://username@hostname:22//home/username/borgstore - absolute

users usually should not need to know the absolute path of their sftp default / "home" directory and server admins should be able to move a user's sftp / "home" directory without breaking the user's backups - thus we default to relative paths now.

absolute paths are still possible, using that "additional slash" hack.