### PR TITLE
use rclone:remote:path as "URL"

### DIFF
--- a/src/borgstore/backends/rclone.py
+++ b/src/borgstore/backends/rclone.py
@@ -40,8 +40,8 @@ if False:
 
 def get_rclone_backend(url):
     """get rclone URL
-    rclone://remote:
-    rclone://remote:path
+    rclone:remote:
+    rclone:remote:path
     """
     # Check rclone is on the path
     try:
@@ -51,7 +51,7 @@ def get_rclone_backend(url):
     if info["decomposed"] < [1, 57, 0]:
         raise BackendDoesNotExist(f"rclone binary too old - need at least version v1.57.0 - found {info['version']}")
     rclone_regex = r"""
-        rclone://
+        rclone:
         (?P<path>(.*))
     """
     m = re.match(rclone_regex, url, re.VERBOSE)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -67,14 +67,14 @@ def check_sftp_available():
 
 def get_rclone_test_backend():
     # To use a specific RCLONE backend
-    # export BORGSTORE_TEST_RCLONE_URL="rclone://remote:path"
+    # export BORGSTORE_TEST_RCLONE_URL="rclone:remote:path"
     # otherwise this will run an rclone backend in a temporary directory on local disk
     url = os.environ.get("BORGSTORE_TEST_RCLONE_URL")
     if not url:
         tempdir = tempfile.mkdtemp()
         # remove the temporary directory since we need to start without it
         os.rmdir(tempdir)
-        url = f"rclone://{tempdir}"
+        url = f"rclone:{tempdir}"
     return get_rclone_backend(url)
 
 


### PR DESCRIPTION
remote:path is a string as defined by the rclone documentation.

these strings can be easy, but they also can get rather complex, see: https://rclone.org/docs/#syntax-of-remote-paths

if they get complex, the whole thing won't look like a standard URL pattern proto://servername/path anyway. also "remote" is not a servername (like something that can be resolved in DNS) but just a name of an entry in the rclone configuration.