### PR TITLE
rclone: fix discard thread issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,7 @@ Use storage on any of the many cloud providers `rclone <https://rclone.org/>`_ s
 - URL: ``rclone:remote:path``, we just prefix "rclone:" and give all to the right
   of that to rclone, see: https://rclone.org/docs/#syntax-of-remote-paths
 - implementation of this primarily depends on the specific remote.
+- rclone binary path can be set via the environment variable RCLONE_BINARY (default value: "rclone")
 
 
 Scalability

--- a/src/borgstore/backends/rclone.py
+++ b/src/borgstore/backends/rclone.py
@@ -79,7 +79,7 @@ class Rclone(BackendBase):
         self.user = "borg"
         self.password = secrets.token_urlsafe(32)
 
-    def find_open_port(self):
+    def find_available_port(self):
         with socket.socket() as s:
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.bind((self.HOST, 0))
@@ -100,7 +100,7 @@ class Rclone(BackendBase):
         if self.process:
             raise BackendMustNotBeOpen()
         while not self.process:
-            port = self.find_open_port()
+            port = self.find_available_port()
             # Open rclone rcd listening on a random port with random auth
             args = [
                 RCLONE,

--- a/src/borgstore/backends/rclone.py
+++ b/src/borgstore/backends/rclone.py
@@ -56,7 +56,7 @@ def get_rclone_backend(url):
         except Exception:
             raise BackendDoesNotExist("rclone binary not found on the path or not working properly")
         if info["decomposed"] < [1, 57, 0]:
-            raise BackendDoesNotExist(f"rclone binary too old - need at least version v1.57.0 - found {info['version']}")
+            raise BackendDoesNotExist(f"rclone version must be at least v1.57.0 - found {info['version']}")
         return Rclone(path=m["path"])
 
 

--- a/src/borgstore/backends/rclone.py
+++ b/src/borgstore/backends/rclone.py
@@ -38,6 +38,7 @@ if False:
     requests_log.setLevel(logging.DEBUG)
     requests_log.propagate = True
 
+
 def get_rclone_backend(url):
     """get rclone URL
     rclone:remote:
@@ -57,6 +58,7 @@ def get_rclone_backend(url):
     m = re.match(rclone_regex, url, re.VERBOSE)
     if m:
         return Rclone(path=m["path"])
+
 
 class Rclone(BackendBase):
     """Borgstore backend for rclone
@@ -204,8 +206,8 @@ class Rclone(BackendBase):
 
     def noop(self, value):
         """noop request that returns back the provided value <value>"""
-        return self._rpc("rc/noop", { "value": value })
-        
+        return self._rpc("rc/noop", {"value": value})
+
     def mkdir(self, name: str) -> None:
         """create directory/namespace <name>"""
         validate_name(name)

--- a/src/borgstore/backends/rclone.py
+++ b/src/borgstore/backends/rclone.py
@@ -44,19 +44,19 @@ def get_rclone_backend(url):
     rclone:remote:
     rclone:remote:path
     """
-    # Check rclone is on the path
-    try:
-        info = json.loads(subprocess.check_output([RCLONE, "rc", "--loopback", "core/version"]))
-    except Exception:
-        raise BackendDoesNotExist("rclone binary not found on the path or not working properly")
-    if info["decomposed"] < [1, 57, 0]:
-        raise BackendDoesNotExist(f"rclone binary too old - need at least version v1.57.0 - found {info['version']}")
     rclone_regex = r"""
         rclone:
         (?P<path>(.*))
     """
     m = re.match(rclone_regex, url, re.VERBOSE)
     if m:
+        # Check rclone is on the path
+        try:
+            info = json.loads(subprocess.check_output([RCLONE, "rc", "--loopback", "core/version"]))
+        except Exception:
+            raise BackendDoesNotExist("rclone binary not found on the path or not working properly")
+        if info["decomposed"] < [1, 57, 0]:
+            raise BackendDoesNotExist(f"rclone binary too old - need at least version v1.57.0 - found {info['version']}")
         return Rclone(path=m["path"])
 
 


### PR DESCRIPTION
This PR fixes two issues:
1. because the while in the discard thread was not checking the value of self.process it would cause an exception to be raised in a thread where no exception handling is present
2. on Cygwin the daemon thread would sometimes not start when thread.start() is called and borg would hang. unsure if it happens on linux though I doubt it.

- keep the discard thread alive only while we have a valid self.process
- mark thread as non daemon - this would cause borg to hang if the rclone process is not indeed closed which should not happen anyway

