### PR TITLE
store: add logging for store ops, fixes #104

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,8 @@ API can be much simpler:
   [us]) and lower bandwidth (via BORGSTORE_BANDWIDTH [bit/s]) than what is
   actually provided by the backend.
 
+Store operations (and per-op timing and volume) are logged at DEBUG log level.
+
 Automatic Nesting
 -----------------
 


### PR DESCRIPTION
logs:
- operation
- name(s)
- params like deleted
- size and timing

note:
- logging is done at debug level, so log output is not visible with a default logger.
- borgstore does not configure logging, that is the task of the application that uses borgstore.