### PR TITLE
Fixing windows file paths

### DIFF
--- a/src/borgstore/backends/posixfs.py
+++ b/src/borgstore/backends/posixfs.py
@@ -29,8 +29,7 @@ def get_file_backend(url):
     # - windows: see there: https://en.wikipedia.org/wiki/File_URI_scheme
     windows_file_regex = r"""
         file://  # protocol and empty or single host slash
-        (/?)(?P<drive>[a-zA-Z]:)  # Drive letter
-        (?P<path>/.*)  # Rest of path, starting with slash
+        (/?)(?P<drive_and_path>([a-zA-Z]:/.*))  # path must be an absolute path.
     """
     file_regex = r"""
         file://  # only empty host part is supported.
@@ -40,7 +39,7 @@ def get_file_backend(url):
         url = url.replace("\\", "/")# Normalise backslashes to forward slashes in the URL path portion
         m = re.match(windows_file_regex, url, re.VERBOSE)
         if m:
-            return PosixFS(path=m["drive"]+m["path"])
+            return PosixFS(path=m["drive_and_path"])
     m = re.match(file_regex, url, re.VERBOSE)
     if m:
         return PosixFS(path=m["path"])

--- a/src/borgstore/backends/posixfs.py
+++ b/src/borgstore/backends/posixfs.py
@@ -37,7 +37,7 @@ def get_file_backend(url):
         (?P<path>(/.*))  # path must be an absolute path. 3rd slash is separator AND part of the path.
     """
     if sys.platform in ("win32", "msys", "cygwin"):
-        url = url.replace("\\", "/")# Normalize backslashes to forward slashes in the URL path portion
+        url = url.replace("\\", "/")# Normalise backslashes to forward slashes in the URL path portion
         m = re.match(windows_file_regex, url, re.VERBOSE)
         if m:
             return PosixFS(path=m["drive"]+m["path"])
@@ -46,7 +46,6 @@ def get_file_backend(url):
         return PosixFS(path=m["path"])
 
     raise BackendError("invalid file:// URL format")
-
 
 class PosixFS(BackendBase):
     # PosixFS implementation supports precreate = True as well as = False.

--- a/src/borgstore/backends/posixfs.py
+++ b/src/borgstore/backends/posixfs.py
@@ -29,8 +29,8 @@ def get_file_backend(url):
     # - windows: see there: https://en.wikipedia.org/wiki/File_URI_scheme
     windows_file_regex = r"""
         file://  # only empty host part is supported.
-        /  # 3rd slash is separator ONLY, not part of the path.
-        (/?)(?P<drive_and_path>([a-zA-Z]:/.*))  # path must be an absolute path.
+        (/?)  # 3rd slash is separator ONLY, not part of the path.
+        (?P<drive_and_path>([a-zA-Z]:/.*))  # path must be an absolute path.
     """
     file_regex = r"""
         file://  # only empty host part is supported.

--- a/src/borgstore/backends/posixfs.py
+++ b/src/borgstore/backends/posixfs.py
@@ -28,7 +28,8 @@ def get_file_backend(url):
     # - the caller is responsible to give an absolute path.
     # - windows: see there: https://en.wikipedia.org/wiki/File_URI_scheme
     windows_file_regex = r"""
-        file://  # protocol and empty or single host slash
+        file://  # only empty host part is supported.
+        /  # 3rd slash is separator ONLY, not part of the path.
         (/?)(?P<drive_and_path>([a-zA-Z]:/.*))  # path must be an absolute path.
     """
     file_regex = r"""

--- a/src/borgstore/backends/posixfs.py
+++ b/src/borgstore/backends/posixfs.py
@@ -27,7 +27,6 @@ def get_file_backend(url):
     #   as the separator between the host and the path part.
     # - the caller is responsible to give an absolute path.
     # - windows: see there: https://en.wikipedia.org/wiki/File_URI_scheme
-    print(url)
     windows_file_regex = r"""
         file://  # protocol and empty or single host slash
         (/?)(?P<drive>[a-zA-Z]:)  # Drive letter
@@ -38,14 +37,12 @@ def get_file_backend(url):
         (?P<path>(/.*))  # path must be an absolute path. 3rd slash is separator AND part of the path.
     """
     if sys.platform in ("win32", "msys", "cygwin"):
-        print(sys.platform)        
         url = url.replace("\\", "/")# Normalize backslashes to forward slashes in the URL path portion
         m = re.match(windows_file_regex, url, re.VERBOSE)
         if m:
             return PosixFS(path=m["drive"]+m["path"])
     m = re.match(file_regex, url, re.VERBOSE)
     if m:
-        print("unix success")
         return PosixFS(path=m["path"])
 
     raise BackendError("invalid file:// URL format")


### PR DESCRIPTION
Msys2 uses forward slashes Windows uses back slashes. Both tests the third slash wasn't there but I left it optional.