### PR TITLE
fix(s3): ensure s3 endpoint is optional

### DIFF
--- a/src/borgstore/backends/s3.py
+++ b/src/borgstore/backends/s3.py
@@ -35,9 +35,12 @@ def get_s3_backend(url: str):
             |
             (?P<access_key_id>[^:@]+):(?P<access_key_secret>[^@]+)  # access key and secret
         )@)?  # optional authentication
-        (?P<schema>[^:/]+)://
-        (?P<hostname>[^:/]+)
-        (:(?P<port>\d+))?/
+        (
+            (?P<schema>[^:/]+)://
+            (?P<hostname>[^:/]+)
+            (:(?P<port>\d+))?
+        )?  # optional endpoint
+        /
         (?P<bucket>[^/]+)/  # bucket name
         (?P<path>.+)  # path
     """


### PR DESCRIPTION
Borg2 documentation and the comment on `get_s3_backend` show the endpoint information is optional however the regex doesn't support this.

```
(s3|b2):[profile|(access_key_id:access_key_secret)@][schema://hostname[:port]]/bucket/path
```

This update ensures the regex supports the optional endpoint configuration.