### PR TITLE
Update release version retrieval in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ from setuptools_scm import get_version
 project = "BorgStore"
 copyright = "2026, Thomas Waldmann"
 author = "Thomas Waldmann"
-release = get_version(root="..", relative_to=__file__)
+release = get_version(root="..", fallback_root="..", relative_to=__file__)
 version = ".".join(release.split(".")[:2])
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
For some reasons, when git tool doesn't exist, the fallback mechanism didn't work, this way we should make sure we detect the version even in Debian builder chroots