### PR TITLE
caching: use partial reads from cache on hits (#182)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Version 0.5.3 (not released yet)
+--------------------------------
+
+Fixes:
+
+- caching: serve partial reads directly from the cache instead of always
+  doing a full load and slicing afterwards, #182
+
 Version 0.5.2 (2026-06-26)
 --------------------------
 

--- a/src/borgstore/store.py
+++ b/src/borgstore/store.py
@@ -380,12 +380,12 @@ class Store:
         with self._stats_updater("info", f"info({name!r}, deleted={deleted})"):
             return self._backend_call(lambda: self.backend.info(self.find(name, deleted=deleted)), volume=0)
 
-    def _cache_load(self, nested_name: str) -> Optional[bytes]:
+    def _cache_load(self, nested_name: str, *, size=None, offset=0) -> Optional[bytes]:
         if self.cache_backend is None or self._cache_disabled:
             return None
         self._stats["cache_load_calls"] += 1
         try:
-            value = self.cache_backend.load(nested_name)
+            value = self.cache_backend.load(nested_name, size=size, offset=offset)
         except ObjectNotFound:
             self._stats["cache_misses"] += 1
             return None
@@ -402,14 +402,18 @@ class Store:
             cache_policy = self._cache_policy_for(name)
             nested_name = self.find(name, deleted=deleted)
             if cache_policy.mode == CacheMode.C_WRITETHROUGH:
-                full_value = self._cache_load(nested_name)
-                if full_value is None:
-                    full_value = self._backend_call(
-                        lambda: self.backend.load(nested_name, size=None, offset=0),
-                        key="load",
-                        volume=lambda value: len(value),
-                    )
-                    self._cache_store(nested_name, full_value)
+                # try a partial read from the cache first, matching the requested range.
+                cached_value = self._cache_load(nested_name, size=size, offset=offset)
+                if cached_value is not None:
+                    self._stats_update_volume("load", len(cached_value))
+                    return cached_value
+                # cache miss: do a full load from the primary backend and populate the cache.
+                full_value = self._backend_call(
+                    lambda: self.backend.load(nested_name, size=None, offset=0),
+                    key="load",
+                    volume=lambda value: len(value),
+                )
+                self._cache_store(nested_name, full_value)
             elif cache_policy.mode == CacheMode.C_MIRROR:
                 full_value = self._backend_call(
                     lambda: self.backend.load(nested_name, size=None, offset=0),

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -173,6 +173,31 @@ def test_c_cache_read_through_and_partial_load(tmp_path):
             assert stats["cache_load_calls"] == 2
             assert stats["cache_hits"] == 1
             assert stats["cache_misses"] == 1
+            # the cache hit was served by a partial read: only the requested 4 bytes were loaded.
+            assert stats["cache_load_volume"] == 4
+    finally:
+        store.destroy()
+
+
+def test_c_cache_hit_uses_partial_read(tmp_path):
+    """On a cache hit, the requested range is read partially from the cache, not fully loaded."""
+    store, _ = make_store(tmp_path, config=make_config({"data/": {"cache": CacheMode.C_WRITETHROUGH}}))
+    store.create()
+    try:
+        with store:
+            name, value = "data/00000000", b"0123456789"
+            store.store(name, value)  # populates the cache (writethrough)
+
+            calls = []
+            orig_load = store.cache_backend.load
+
+            def spy_load(nested_name, *, size=None, offset=0):
+                calls.append((size, offset))
+                return orig_load(nested_name, size=size, offset=offset)
+
+            store.cache_backend.load = spy_load
+            assert store.load(name, size=4, offset=2) == value[2:6]
+            assert calls == [(4, 2)]
     finally:
         store.destroy()
 


### PR DESCRIPTION
Fixes #182.

## Problem

On a cache hit, `Store.load()` always did a *full* load from the cache backend and only reduced the data to the requested range afterwards by slicing. For partial reads (`size`/`offset` given) this transfers and allocates far more data than necessary.

## Change

In the `C_WRITETHROUGH` path, `load()` now passes `size`/`offset` through to the cache backend, so a cache hit is served by a partial read matching the requested range. The cache-miss path is unchanged: it still does a full load from the primary backend and populates the cache with the full object.

`_cache_load()` grows `size`/`offset` keyword arguments (default to a full read), so other callers are unaffected.

## Tests

- `test_c_cache_read_through_and_partial_load` now also asserts `cache_load_volume == 4`, proving only the requested 4 bytes were read on the hit.
- Added `test_c_cache_hit_uses_partial_read`, which spies on the cache backend's `load()` and asserts it is invoked with `(size=4, offset=2)`.

All `tests/test_store.py` and `tests/test_cache.py` pass (40 passed, 2 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)