### PR TITLE
sftp: recover from lost connection instead of hanging forever, fixes #167

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,9 @@ Version 0.5.4 (not released yet)
 
 Fixes:
 
+- sftp: recover from a lost connection instead of hanging forever. Operations now use a
+  socket timeout and, on a broken/dead connection, transparently reconnect and retry (and
+  give up with a BackendError if the connection can't be reestablished), #167
 - Spawn rclone and ssh ignoring SIGINT, so they don't get interrupted by Ctrl-C.
 
 

--- a/src/borgstore/backends/sftp.py
+++ b/src/borgstore/backends/sftp.py
@@ -4,9 +4,14 @@ SFTP-based backend implementation — on an SFTP server, uses files in directori
 
 from pathlib import Path
 from urllib.parse import unquote
+import errno
+import functools
+import logging
 import random
 import re
+import socket
 import stat
+import time
 from typing import Optional
 
 try:
@@ -18,6 +23,102 @@ from ._base import BackendBase, ItemInfo, validate_name
 from .errors import BackendError, BackendMustBeOpen, BackendMustNotBeOpen, BackendDoesNotExist, BackendAlreadyExists
 from .errors import ObjectNotFound
 from ..constants import TMP_SUFFIX
+
+logger = logging.getLogger(__name__)
+
+# How long to wait (seconds) for the initial connection / authentication to complete.
+DEFAULT_CONNECT_TIMEOUT = 30.0
+# Send an SSH keepalive every N seconds. This keeps NAT/firewall state alive and, together with
+# the socket timeout below, helps notice a dead connection reasonably quickly.
+DEFAULT_KEEPALIVE_INTERVAL = 30.0
+# If no data is received on the SFTP channel for this long, the operation raises socket.timeout
+# instead of blocking forever. This is what turns a "dead" connection (e.g. after the laptop was
+# suspended and the network went away) into a recoverable error instead of an infinite hang.
+DEFAULT_SOCKET_TIMEOUT = 120.0
+# When the connection was lost, try this many times to reconnect and redo the failed operation.
+DEFAULT_RECONNECT_TRIES = 3
+# Wait this long (seconds) between reconnect attempts.
+DEFAULT_RECONNECT_WAIT = 5.0
+
+# errnos that mean "the connection is gone" (as opposed to e.g. ENOENT / EACCES which are legit results).
+_CONNECTION_LOST_ERRNOS = frozenset(
+    e
+    for e in (
+        getattr(errno, name, None)
+        for name in (
+            "EPIPE",
+            "ECONNRESET",
+            "ECONNABORTED",
+            "ENETDOWN",
+            "ENETRESET",
+            "ENETUNREACH",
+            "EHOSTDOWN",
+            "EHOSTUNREACH",
+            "ETIMEDOUT",
+            "ESHUTDOWN",
+        )
+    )
+    if e is not None
+)
+
+
+def _is_connection_lost(exc: BaseException) -> bool:
+    """Return True if exc indicates a broken/dead connection (something a reconnect could fix)."""
+    if isinstance(exc, (EOFError, socket.timeout, ConnectionError)):
+        # socket.timeout is our own doing (see DEFAULT_SOCKET_TIMEOUT); EOFError is raised by
+        # paramiko when the server connection dropped; ConnectionError covers reset/aborted/refused.
+        return True
+    if paramiko is not None and isinstance(exc, paramiko.SSHException):
+        # transport/protocol level failures, e.g. "Server connection dropped".
+        return True
+    if isinstance(exc, OSError) and exc.errno in _CONNECTION_LOST_ERRNOS:
+        # low-level socket errors. Note: FileNotFoundError/PermissionError are OSError subclasses too,
+        # but their errnos (ENOENT/EACCES) are not in the set, so they are correctly treated as real results.
+        return True
+    return False
+
+
+def with_reconnect(method):
+    """Decorator: if the wrapped method fails because the connection was lost, reconnect and retry.
+
+    This is only active while the backend is opened. Errors that are not connection losses
+    (e.g. ObjectNotFound, FileNotFoundError, PermissionError) are passed through unchanged.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return method(self, *args, **kwargs)
+        except Exception as exc:
+            if not (self.opened and _is_connection_lost(exc)):
+                raise
+            logger.warning("sftp: connection lost (%r), trying to reconnect...", exc)
+        last_exc: Optional[BaseException] = None
+        for attempt in range(1, self.reconnect_tries + 1):
+            time.sleep(self.reconnect_wait)
+            try:
+                self._reconnect()
+            except Exception as exc:
+                last_exc = exc
+                if not _is_connection_lost(exc):
+                    raise
+                logger.warning("sftp: reconnect attempt %d/%d failed: %r", attempt, self.reconnect_tries, exc)
+                continue
+            try:
+                result = method(self, *args, **kwargs)
+            except Exception as exc:
+                last_exc = exc
+                if not _is_connection_lost(exc):
+                    raise
+                logger.warning(
+                    "sftp: retry after reconnect (attempt %d/%d) failed: %r", attempt, self.reconnect_tries, exc
+                )
+                continue
+            logger.info("sftp: reconnected successfully (attempt %d).", attempt)
+            return result
+        raise BackendError(f"sftp connection was lost and could not be reestablished: {last_exc!r}")
+
+    return wrapper
 
 
 def get_sftp_backend(url):
@@ -60,11 +161,27 @@ class Sftp(BackendBase):
     # Sftp implementation supports precreate = True as well as = False.
     precreate_dirs: bool = False
 
-    def __init__(self, hostname: str, path: str, port: int = 0, username: Optional[str] = None):
+    def __init__(
+        self,
+        hostname: str,
+        path: str,
+        port: int = 0,
+        username: Optional[str] = None,
+        connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+        keepalive_interval: float = DEFAULT_KEEPALIVE_INTERVAL,
+        socket_timeout: float = DEFAULT_SOCKET_TIMEOUT,
+        reconnect_tries: int = DEFAULT_RECONNECT_TRIES,
+        reconnect_wait: float = DEFAULT_RECONNECT_WAIT,
+    ):
         self.username = username
         self.hostname = hostname
         self.port = port
         self.base_path = path
+        self.connect_timeout = connect_timeout
+        self.keepalive_interval = keepalive_interval
+        self.socket_timeout = socket_timeout
+        self.reconnect_tries = reconnect_tries
+        self.reconnect_wait = reconnect_wait
         self.opened = False
         self.check_file_supported = True
         self.ssh: Optional[paramiko.SSHClient] = None
@@ -115,19 +232,53 @@ class Sftp(BackendBase):
                 port=int(host_config["port"]),
                 key_filename=host_config.get("identityfile"),  # list of keys, ~ is already expanded
                 allow_agent=True,
+                # bound the time we wait to establish the connection / authenticate, so a dead
+                # network does not make us block forever already at connect time.
+                timeout=self.connect_timeout,
+                banner_timeout=self.connect_timeout,
+                auth_timeout=self.connect_timeout,
             )
+            transport = self.ssh.get_transport()
+            if transport is not None and self.keepalive_interval:
+                # keep NAT/firewall state alive and notice a dead peer sooner.
+                transport.set_keepalive(int(self.keepalive_interval))
             self.client = self.ssh.open_sftp()
+            if self.socket_timeout:
+                # crucial: without a timeout, an operation on a dead connection (e.g. after the
+                # machine was suspended and the network went away) would block forever. With a
+                # timeout it raises socket.timeout, which we turn into a reconnect (see with_reconnect).
+                channel = self.client.get_channel()
+                if channel is not None:
+                    channel.settimeout(self.socket_timeout)
         except Exception:
             self._disconnect()
             raise
 
     def _disconnect(self):
-        if self.client:
-            self.client.close()
+        # be robust: closing a already-dead connection may itself raise, but we still want to
+        # drop our references so a following _connect starts from a clean slate.
+        try:
+            if self.client:
+                self.client.close()
+        except Exception:
+            pass
+        finally:
             self.client = None
-        if self.ssh:
-            self.ssh.close()
+        try:
+            if self.ssh:
+                self.ssh.close()
+        except Exception:
+            pass
+        finally:
             self.ssh = None
+
+    def _reconnect(self):
+        """Drop a (likely broken) connection and establish a fresh, working one."""
+        self._disconnect()
+        self._connect()
+        # .open() changed the working directory into base_path and all operations use relative
+        # names, so we must restore that after reconnecting.
+        self.client.chdir(self.base_path)
 
     def create(self):
         if self.opened:
@@ -216,12 +367,14 @@ class Sftp(BackendBase):
             if not exist_ok:
                 raise
 
+    @with_reconnect
     def mkdir(self, name):
         if not self.opened:
             raise BackendMustBeOpen()
         validate_name(name)
         self._mkdir(name, parents=True, exist_ok=True)
 
+    @with_reconnect
     def rmdir(self, name):
         if not self.opened:
             raise BackendMustBeOpen()
@@ -231,6 +384,7 @@ class Sftp(BackendBase):
         except FileNotFoundError:
             raise ObjectNotFound(name) from None
 
+    @with_reconnect
     def info(self, name):
         if not self.opened:
             raise BackendMustBeOpen()
@@ -243,6 +397,7 @@ class Sftp(BackendBase):
             is_dir = stat.S_ISDIR(st.st_mode)
             return ItemInfo(name=name, exists=True, directory=is_dir, size=st.st_size)
 
+    @with_reconnect
     def load(self, name, *, size=None, offset=0):
         if not self.opened:
             raise BackendMustBeOpen()
@@ -255,6 +410,7 @@ class Sftp(BackendBase):
         except FileNotFoundError:
             raise ObjectNotFound(name) from None
 
+    @with_reconnect
     def store(self, name, value):
         def _write_to_tmpfile():
             with self.client.open(tmp_name, mode="w") as f:
@@ -285,6 +441,7 @@ class Sftp(BackendBase):
             self.client.unlink(tmp_name)
             raise
 
+    @with_reconnect
     def delete(self, name):
         if not self.opened:
             raise BackendMustBeOpen()
@@ -309,6 +466,7 @@ class Sftp(BackendBase):
                 self.check_file_supported = False
         return None
 
+    @with_reconnect
     def hash(self, name: str, algorithm: str = "sha256") -> str:
         if not self.opened:
             raise BackendMustBeOpen()
@@ -318,6 +476,7 @@ class Sftp(BackendBase):
             return hexdigest
         return super().hash(name, algorithm=algorithm)
 
+    @with_reconnect
     def move(self, curr_name, new_name):
         def _rename_to_new_name():
             self.client.posix_rename(curr_name, new_name)
@@ -341,20 +500,26 @@ class Sftp(BackendBase):
             except FileNotFoundError:
                 raise ObjectNotFound(curr_name) from None
 
+    @with_reconnect
+    def _listdir_attr(self, name):
+        # separate, decorated helper because .list() is a generator: connection errors would be
+        # raised while iterating, i.e. outside the reconnect wrapper. Fetching the whole listing
+        # here means the (retryable) network access happens inside with_reconnect.
+        try:
+            return self.client.listdir_attr(name)
+        except FileNotFoundError:
+            raise ObjectNotFound(name) from None
+
     def list(self, name):
         if not self.opened:
             raise BackendMustBeOpen()
         validate_name(name)
-        try:
-            infos = self.client.listdir_attr(name)
-        except FileNotFoundError:
-            raise ObjectNotFound(name) from None
-        else:
-            for info in sorted(infos, key=lambda i: i.filename):
-                try:
-                    validate_name(info.filename)
-                except ValueError:
-                    pass  # that file is likely not from us or is still uploading
-                else:
-                    is_dir = stat.S_ISDIR(info.st_mode)
-                    yield ItemInfo(name=info.filename, exists=True, size=info.st_size, directory=is_dir)
+        infos = self._listdir_attr(name)
+        for info in sorted(infos, key=lambda i: i.filename):
+            try:
+                validate_name(info.filename)
+            except ValueError:
+                pass  # that file is likely not from us or is still uploading
+            else:
+                is_dir = stat.S_ISDIR(info.st_mode)
+                yield ItemInfo(name=info.filename, exists=True, size=info.st_size, directory=is_dir)

--- a/src/borgstore/backends/sftp.py
+++ b/src/borgstore/backends/sftp.py
@@ -78,12 +78,22 @@ def _is_connection_lost(exc: BaseException) -> bool:
     return False
 
 
-def with_reconnect(method):
+def with_reconnect(method=None, *, swallow_not_found=False):
     """Decorator: if the wrapped method fails because the connection was lost, reconnect and retry.
 
     This is only active while the backend is opened. Errors that are not connection losses
     (e.g. ObjectNotFound, FileNotFoundError, PermissionError) are passed through unchanged.
+
+    Usable both bare (``@with_reconnect``) and with arguments (``@with_reconnect(...)``).
+
+    swallow_not_found: only for idempotent removals (delete/move). The retry path is only reached
+    after a connection loss on an earlier attempt, so if that earlier attempt had already succeeded
+    (just the reply got lost), the retried operation raises ObjectNotFound. For delete/move that is
+    a spurious error - the desired end state (object gone / moved) is reached - so we swallow it and
+    report success. On the very first attempt ObjectNotFound is a real result and still propagates.
     """
+    if method is None:
+        return functools.partial(with_reconnect, swallow_not_found=swallow_not_found)
 
     @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
@@ -106,6 +116,12 @@ def with_reconnect(method):
                 continue
             try:
                 result = method(self, *args, **kwargs)
+            except ObjectNotFound:
+                if not swallow_not_found:
+                    raise
+                # an earlier attempt (before the connection loss) most likely already did it.
+                logger.info("sftp: reconnected (attempt %d); object already gone, treating as success.", attempt)
+                return None
             except Exception as exc:
                 last_exc = exc
                 if not _is_connection_lost(exc):
@@ -441,7 +457,7 @@ class Sftp(BackendBase):
             self.client.unlink(tmp_name)
             raise
 
-    @with_reconnect
+    @with_reconnect(swallow_not_found=True)
     def delete(self, name):
         if not self.opened:
             raise BackendMustBeOpen()
@@ -476,7 +492,7 @@ class Sftp(BackendBase):
             return hexdigest
         return super().hash(name, algorithm=algorithm)
 
-    @with_reconnect
+    @with_reconnect(swallow_not_found=True)
     def move(self, curr_name, new_name):
         def _rename_to_new_name():
             self.client.posix_rename(curr_name, new_name)

--- a/tests/test_sftp_reconnect.py
+++ b/tests/test_sftp_reconnect.py
@@ -1,0 +1,134 @@
+"""
+Tests for the SFTP backend's connection-loss recovery (see issue #167).
+
+These tests do not need a real SFTP server: they exercise the with_reconnect decorator and the
+_is_connection_lost helper in isolation, simulating a dead connection.
+"""
+
+import errno
+import socket
+
+import pytest
+
+paramiko = pytest.importorskip("paramiko")
+
+from borgstore.backends.errors import BackendError, ObjectNotFound
+from borgstore.backends.sftp import Sftp, with_reconnect, _is_connection_lost
+
+
+@pytest.mark.parametrize(
+    "exc, expected",
+    [
+        (socket.timeout(), True),
+        (EOFError(), True),
+        (ConnectionResetError(), True),
+        (paramiko.SSHException("Server connection dropped"), True),
+        (OSError(errno.EPIPE, "broken pipe"), True),
+        (OSError(errno.ECONNRESET, "reset"), True),
+        # legit results, must NOT be treated as connection loss:
+        (FileNotFoundError(errno.ENOENT, "no such file"), False),
+        (PermissionError(errno.EACCES, "denied"), False),
+        (ObjectNotFound("x"), False),
+        (ValueError("nope"), False),
+    ],
+)
+def test_is_connection_lost(exc, expected):
+    assert _is_connection_lost(exc) is expected
+
+
+class FakeSftp:
+    """Minimal stand-in providing exactly what with_reconnect touches."""
+
+    def __init__(self, reconnect_tries=3):
+        self.opened = True
+        self.reconnect_tries = reconnect_tries
+        self.reconnect_wait = 0  # do not slow down the tests
+        self.reconnects = 0
+        self.reconnect_should_fail = False
+
+    def _reconnect(self):
+        self.reconnects += 1
+        if self.reconnect_should_fail:
+            raise socket.timeout()
+
+
+def test_retry_succeeds_after_reconnect():
+    obj = FakeSftp()
+    calls = {"n": 0}
+
+    @with_reconnect
+    def op(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise socket.timeout()  # first call: connection is dead
+        return "ok"  # after reconnect: works
+
+    assert op(obj) == "ok"
+    assert obj.reconnects == 1
+    assert calls["n"] == 2
+
+
+def test_no_retry_for_non_connection_error():
+    obj = FakeSftp()
+
+    @with_reconnect
+    def op(self):
+        raise ObjectNotFound("missing")
+
+    with pytest.raises(ObjectNotFound):
+        op(obj)
+    assert obj.reconnects == 0  # ObjectNotFound must not trigger a reconnect
+
+
+def test_gives_up_after_all_tries():
+    obj = FakeSftp(reconnect_tries=3)
+
+    @with_reconnect
+    def op(self):
+        raise socket.timeout()  # never recovers
+
+    with pytest.raises(BackendError):
+        op(obj)
+    assert obj.reconnects == 3
+
+
+def test_not_opened_does_not_reconnect():
+    obj = FakeSftp()
+    obj.opened = False
+
+    @with_reconnect
+    def op(self):
+        raise socket.timeout()
+
+    with pytest.raises(socket.timeout):
+        op(obj)
+    assert obj.reconnects == 0
+
+
+def test_reconnect_restores_working_directory(monkeypatch):
+    """After a reconnect we must chdir back into base_path so relative names keep working."""
+    be = Sftp(hostname="example", path="some/base/path")
+
+    class FakeClient:
+        def __init__(self):
+            self.cwd = None
+
+        def chdir(self, path):
+            self.cwd = path
+
+    connects = {"n": 0}
+
+    def fake_connect():
+        connects["n"] += 1
+        be.client = FakeClient()
+
+    def fake_disconnect():
+        be.client = None
+
+    monkeypatch.setattr(be, "_connect", fake_connect)
+    monkeypatch.setattr(be, "_disconnect", fake_disconnect)
+
+    be._reconnect()
+
+    assert connects["n"] == 1
+    assert be.client.cwd == "some/base/path"

--- a/tests/test_sftp_reconnect.py
+++ b/tests/test_sftp_reconnect.py
@@ -92,6 +92,52 @@ def test_gives_up_after_all_tries():
     assert obj.reconnects == 3
 
 
+def test_swallow_not_found_on_retry():
+    """delete/move: ObjectNotFound after a reconnect means the earlier attempt already did it."""
+    obj = FakeSftp()
+    calls = {"n": 0}
+
+    @with_reconnect(swallow_not_found=True)
+    def op(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise socket.timeout()  # connection died (the op may already have succeeded)
+        raise ObjectNotFound("gone")  # retry: object is already gone -> treat as success
+
+    assert op(obj) is None
+    assert obj.reconnects == 1
+
+
+def test_object_not_found_propagates_on_first_attempt_even_when_swallowing():
+    """A genuine ObjectNotFound (no connection loss) must still propagate."""
+    obj = FakeSftp()
+
+    @with_reconnect(swallow_not_found=True)
+    def op(self):
+        raise ObjectNotFound("gone")
+
+    with pytest.raises(ObjectNotFound):
+        op(obj)
+    assert obj.reconnects == 0
+
+
+def test_object_not_found_on_retry_propagates_without_swallow():
+    """Without swallow_not_found, ObjectNotFound on the retry path propagates as-is."""
+    obj = FakeSftp()
+    calls = {"n": 0}
+
+    @with_reconnect
+    def op(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise socket.timeout()
+        raise ObjectNotFound("gone")
+
+    with pytest.raises(ObjectNotFound):
+        op(obj)
+    assert obj.reconnects == 1
+
+
 def test_not_opened_does_not_reconnect():
     obj = FakeSftp()
     obj.opened = False


### PR DESCRIPTION
## Problem (#167)

The SFTP backend created the paramiko connection without any timeouts or keepalive. When the network went away (e.g. laptop suspended and reopened later), an in-flight SFTP operation blocked **forever** on a socket read, so borg neither recovered nor quit — and Ctrl-C couldn't break out because the hang was in a blocking C-level `recv`.

## Fix

**Stop hanging.** `_connect()` now sets connect/banner/auth timeouts, an SSH keepalive, and — crucially — a **socket timeout on the SFTP channel**. A dead connection now surfaces as `socket.timeout` / `EOFError` instead of blocking indefinitely.

**Reconnect and retry.** A `with_reconnect` decorator wraps the remote operations (`load`, `store`, `info`, `list`, `delete`, `mkdir`, `rmdir`, `move`, `hash`). On a connection-loss error it reconnects (disconnect → fresh connect → `chdir` back into `base_path` so relative names keep working) and retries, up to `reconnect_tries` times. If the connection can't be reestablished it raises `BackendError`, so borg quits cleanly rather than hanging.

`_is_connection_lost()` classifies errors by type/errno but deliberately **excludes** `FileNotFoundError` / `PermissionError` / `ObjectNotFound`, so legitimate "not found" results are never mistaken for a dead connection. `list()` is a generator, so its network access is pulled into a decorated `_listdir_attr()` helper (otherwise the error would fire during iteration, outside the wrapper).

All timeouts and retry counts are constructor parameters with sensible defaults (120s socket timeout, 30s keepalive, 3 retries).

## Retry semantics (at-least-once)

Retries are at-least-once: if a `store`/`move`/`delete` succeeded but the reply was lost to the connection drop, the retry re-runs it. `store` is idempotent (overwrites). For the idempotent removals `delete`/`move`, `with_reconnect` takes an opt-in `swallow_not_found=True`: on the **retry path only** (which is reached exclusively after a connection loss), an `ObjectNotFound` means an earlier attempt most likely already did it, so it is treated as success instead of surfacing a spurious error. A genuine `ObjectNotFound` on the first attempt (no connection loss) still propagates, and `load`/`info`/`list` are unaffected.

## Tests

- New `tests/test_sftp_reconnect.py` (18 tests, no live server needed): error classifier, retry-then-succeed, no-retry-on-`ObjectNotFound`, give-up-after-N-tries, no-reconnect-when-closed, cwd restoration, and the `swallow_not_found` behavior (swallow-on-retry, genuine-not-found-still-propagates, not-found-on-retry-propagates-without-the-flag).
- Existing `tests/test_backends.py`: 29 passed, 15 skipped (SFTP live tests), no regressions.
- `black` + `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)