### PR TITLE
rest: recover from lost ssh connection instead of hanging forever, #167

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,8 @@ Fixes:
   command now uses keepalive (ServerAliveInterval/CountMax) so a dead peer is noticed, and on a
   broken connection the client transparently restarts the ssh + server process and retries the
   request (giving up with a BackendError if it can't be reestablished), #167
+- rest (stdio-over-ssh): raise BackendConnectionError on unexpected EOF during response headers
+  or response body transfer, preventing silent data truncation.
 
 
 Version 0.5.4 (2026-07-09)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Version 0.5.5 (not released yet)
+--------------------------------
+
+Fixes:
+
+- rest (stdio-over-ssh): recover from a lost ssh connection instead of hanging forever. The ssh
+  command now uses keepalive (ServerAliveInterval/CountMax) so a dead peer is noticed, and on a
+  broken connection the client transparently restarts the ssh + server process and retries the
+  request (giving up with a BackendError if it can't be reestablished), #167
+
+
 Version 0.5.4 (2026-07-09)
 --------------------------
 

--- a/src/borgstore/backends/errors.py
+++ b/src/borgstore/backends/errors.py
@@ -7,6 +7,10 @@ class BackendError(Exception):
     """Base class for exceptions in this module."""
 
 
+class BackendConnectionError(BackendError):
+    """Raised when the connection to the backend was lost. This may be recoverable by reconnecting."""
+
+
 class BackendURLInvalid(BackendError):
     """Raised when trying to create a store using an invalid backend URL."""
 

--- a/src/borgstore/backends/rest.py
+++ b/src/borgstore/backends/rest.py
@@ -3,6 +3,7 @@ REST http client based backend implementation (use with borgstore.server.rest).
 """
 
 import collections
+import functools
 import os
 import re
 import shlex
@@ -11,6 +12,7 @@ import logging
 import hashlib
 import threading
 import subprocess
+import time
 from typing import Iterator, Dict, Optional
 from types import ModuleType
 from http import HTTPStatus as HTTP
@@ -32,6 +34,7 @@ from ._utils import make_range_header, ignore_sigint
 from .errors import (
     ObjectNotFound,
     BackendAlreadyExists,
+    BackendConnectionError,
     BackendDoesNotExist,
     PermissionDenied,
     QuotaExceeded,
@@ -41,6 +44,91 @@ from .errors import (
 )
 
 logger = logging.getLogger(__name__)
+
+# ssh keepalive: make ssh notice a dead peer and terminate (which closes the stdio pipe and unblocks
+# our reads) instead of us blocking forever on a read from a connection that will never answer.
+# ssh gives up after roughly SSH_ALIVE_INTERVAL * SSH_ALIVE_COUNT_MAX seconds of silence.
+SSH_ALIVE_INTERVAL = 30
+SSH_ALIVE_COUNT_MAX = 3
+# When the connection was lost, try this many times to reconnect and redo the failed operation.
+DEFAULT_RECONNECT_TRIES = 3
+# Wait this long (seconds) between reconnect attempts.
+DEFAULT_RECONNECT_WAIT = 5.0
+
+
+def _is_connection_lost(exc: BaseException) -> bool:
+    """Return True if exc indicates a broken/dead connection (something a reconnect could fix)."""
+    if isinstance(exc, BackendConnectionError):
+        # raised by StdioSession when the ssh/stdio pipe broke (see request()/close()).
+        return True
+    if isinstance(exc, (BrokenPipeError, ConnectionError, EOFError)):
+        return True
+    if requests is not None and isinstance(
+        exc,
+        (requests.exceptions.ConnectionError, requests.exceptions.Timeout, requests.exceptions.ChunkedEncodingError),
+    ):
+        # plain http(s) mode: connection reset/timeout while talking to the server.
+        return True
+    return False
+
+
+def with_reconnect(method=None, *, swallow_not_found=False):
+    """Decorator: if the wrapped method fails because the connection was lost, reconnect and retry.
+
+    This is only active while the backend is opened (has a session). Errors that are not connection
+    losses (e.g. ObjectNotFound, PermissionDenied) are passed through unchanged.
+
+    Usable both bare (``@with_reconnect``) and with arguments (``@with_reconnect(...)``).
+
+    swallow_not_found: only for idempotent removals (delete/move). The retry path is only reached
+    after a connection loss on an earlier attempt, so if that earlier attempt had already succeeded
+    (just the reply got lost), the retried operation raises ObjectNotFound. For delete/move that is
+    a spurious error - the desired end state is reached - so we swallow it and report success. On the
+    very first attempt ObjectNotFound is a real result and still propagates.
+    """
+    if method is None:
+        return functools.partial(with_reconnect, swallow_not_found=swallow_not_found)
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return method(self, *args, **kwargs)
+        except Exception as exc:
+            if not (self.session is not None and _is_connection_lost(exc)):
+                raise
+            logger.warning("rest: connection lost (%r), trying to reconnect...", exc)
+        last_exc: Optional[BaseException] = None
+        for attempt in range(1, self.reconnect_tries + 1):
+            time.sleep(self.reconnect_wait)
+            try:
+                self._reconnect()
+            except Exception as exc:
+                last_exc = exc
+                if not _is_connection_lost(exc):
+                    raise
+                logger.warning("rest: reconnect attempt %d/%d failed: %r", attempt, self.reconnect_tries, exc)
+                continue
+            try:
+                result = method(self, *args, **kwargs)
+            except ObjectNotFound:
+                if not swallow_not_found:
+                    raise
+                # an earlier attempt (before the connection loss) most likely already did it.
+                logger.info("rest: reconnected (attempt %d); object already gone, treating as success.", attempt)
+                return None
+            except Exception as exc:
+                last_exc = exc
+                if not _is_connection_lost(exc):
+                    raise
+                logger.warning(
+                    "rest: retry after reconnect (attempt %d/%d) failed: %r", attempt, self.reconnect_tries, exc
+                )
+                continue
+            logger.info("rest: reconnected successfully (attempt %d).", attempt)
+            return result
+        raise BackendError(f"rest connection was lost and could not be reestablished: {last_exc!r}")
+
+    return wrapper
 
 
 class StdioSession:
@@ -134,18 +222,25 @@ class StdioSession:
 
         request_line = f"{prepared.method} {prepared.path_url} HTTP/1.1\r\n"
         header_lines = "".join(f"{k}: {v}\r\n" for k, v in prepared.headers.items())
-        self.process.stdin.write((request_line + header_lines + "\r\n").encode("ascii"))
-        if body:
-            self.process.stdin.write(body)
-        self.process.stdin.flush()
+        try:
+            self.process.stdin.write((request_line + header_lines + "\r\n").encode("ascii"))
+            if body:
+                self.process.stdin.write(body)
+            self.process.stdin.flush()
+        except (BrokenPipeError, OSError) as e:
+            # the stdio pipe broke while sending, i.e. the ssh/server process is gone.
+            raise BackendConnectionError(f"stdio connection lost while sending request: {e}") from e
 
         line = self.process.stdout.readline()
         if not line:
+            # EOF: the ssh/server process closed the pipe. With ssh keepalive this is also how a
+            # dead network connection surfaces (ssh notices the dead peer and exits). Treat it as a
+            # (recoverable) connection loss rather than a plain backend error.
             if self._stderr_thread is not None:
                 self._stderr_thread.join(timeout=0.5)
             stderr_tail = "\n".join(self._stderr_lines)
             detail = f":\n{stderr_tail}" if stderr_tail else ""
-            raise BackendError(f"stdio server closed connection unexpectedly{detail}")
+            raise BackendConnectionError(f"stdio server closed connection unexpectedly{detail}")
         status_line = line.decode("iso-8859-1").strip()
         parts = status_line.split(" ", 2)
         if len(parts) < 2:
@@ -181,9 +276,13 @@ def ssh_cmd(user, host, port):
     """return an ssh command line that can be prefixed to another command line"""
     rsh = os.environ.get("BORGSTORE_RSH")
     if rsh:
+        # a custom remote shell is used verbatim - the user is in control of its options
+        # (including any keepalive), so we do not add anything here.
         args = shlex.split(rsh)
     else:
         args = ["ssh"]
+        # keepalive: make ssh terminate on a dead peer instead of letting our stdio reads hang forever.
+        args += ["-o", f"ServerAliveInterval={SSH_ALIVE_INTERVAL}", "-o", f"ServerAliveCountMax={SSH_ALIVE_COUNT_MAX}"]
         if port:
             args += ["-p", str(port)]
     args += [f"{user}@{host}"] if user else [host]
@@ -272,6 +371,8 @@ class REST(BackendBase):
         headers: Optional[Dict[str, str]] = None,
         timeout: Optional[int] = 30,
         command=None,
+        reconnect_tries: int = DEFAULT_RECONNECT_TRIES,
+        reconnect_wait: float = DEFAULT_RECONNECT_WAIT,
     ):
         self.base_url = base_url.rstrip("/")  # _url method adds slash
         self.headers = headers or {}
@@ -279,6 +380,8 @@ class REST(BackendBase):
         self.timeout = timeout
         self.auth = HTTPBasicAuth(username, password) if username and password else None
         self.command = command
+        self.reconnect_tries = reconnect_tries
+        self.reconnect_wait = reconnect_wait
         self.session = None
 
     def _url(self, path: str) -> str:
@@ -360,18 +463,38 @@ class REST(BackendBase):
         self.session.close()
         self.session = None
 
+    def _reconnect(self):
+        """Drop a (likely broken) session and establish a fresh, working one.
+
+        For stdio mode this restarts the ssh + borgstore-server-rest process; for plain http(s) mode
+        it creates a new requests.Session. The server holds no cross-request state, so redoing the
+        failed request against the fresh session is safe.
+        """
+        try:
+            if self.session is not None:
+                self.session.close()
+        except Exception:
+            # closing a already-broken session may itself raise (e.g. nonzero ssh exit) - ignore it,
+            # we only care about getting a clean, fresh session below.
+            pass
+        self.session = None
+        self.open()
+
+    @with_reconnect
     def mkdir(self, name: str) -> None:
         self._assert_open()
         validate_name(name)
         response = self._request("post", self._url(name), params={"cmd": "mkdir"})
         self._handle_response(response, name)
 
+    @with_reconnect
     def rmdir(self, name: str) -> None:
         self._assert_open()
         validate_name(name)
         response = self._request("delete", self._url(name), params={"cmd": "rmdir"})
         self._handle_response(response, name)
 
+    @with_reconnect
     def info(self, name: str) -> ItemInfo:
         self._assert_open()
         validate_name(name)
@@ -384,6 +507,7 @@ class REST(BackendBase):
         size = int(response.headers.get("Content-Length", 0)) if exists else 0
         return ItemInfo(name=name, exists=exists, size=size, directory=is_dir, atime=atime)
 
+    @with_reconnect
     def load(self, name: str, *, size=None, offset=0) -> bytes:
         self._assert_open()
         validate_name(name)
@@ -410,6 +534,7 @@ class REST(BackendBase):
             content = content[:size]
         return content
 
+    @with_reconnect
     def store(self, name: str, value: bytes) -> None:
         self._assert_open()
         validate_name(name)
@@ -418,12 +543,14 @@ class REST(BackendBase):
         response = self._request("post", self._url(name), data=value, headers=headers)
         self._handle_response(response, name)
 
+    @with_reconnect(swallow_not_found=True)
     def delete(self, name: str) -> None:
         self._assert_open()
         validate_name(name)
         response = self._request("delete", self._url(name))
         self._handle_response(response, name)
 
+    @with_reconnect(swallow_not_found=True)
     def move(self, curr_name: str, new_name: str) -> None:
         self._assert_open()
         validate_name(curr_name)
@@ -431,6 +558,7 @@ class REST(BackendBase):
         response = self._request("post", self._url(""), params={"cmd": "move", "current": curr_name, "new": new_name})
         self._handle_response(response, f"{curr_name} -> {new_name}")
 
+    @with_reconnect
     def defrag(self, sources, *, target=None, algorithm=None, namespace=None, levels=0) -> str:
         self._assert_open()
         params = {"cmd": "defrag"}
@@ -447,12 +575,14 @@ class REST(BackendBase):
         self._handle_response(response, "defrag")
         return response.text
 
+    @with_reconnect
     def quota(self) -> dict:
         self._assert_open()
         response = self._request("post", self._url(""), params={"cmd": "quota"})
         self._handle_response(response, "quota")
         return response.json()
 
+    @with_reconnect
     def hash(self, name: str, algorithm: str = "sha256") -> str:
         self._assert_open()
         validate_name(name)
@@ -460,12 +590,19 @@ class REST(BackendBase):
         self._handle_response(response, name)
         return response.text
 
-    def list(self, name: str) -> Iterator[ItemInfo]:
+    @with_reconnect
+    def _list_entries(self, name: str) -> list:
+        # separate, decorated helper because .list() is a generator: connection errors would be
+        # raised while iterating, i.e. outside the reconnect wrapper. Doing the request (and fully
+        # materializing the json) here means the (retryable) network access happens inside with_reconnect.
         self._assert_open()
         validate_name(name)
         response = self._request("get", self._url(name) + "/")  # trailing "/" needed to get list
         self._handle_response(response, name)
-        for entry in response.json():
+        return response.json()
+
+    def list(self, name: str) -> Iterator[ItemInfo]:
+        for entry in self._list_entries(name):
             yield ItemInfo(
                 name=entry["name"],
                 exists=True,

--- a/src/borgstore/backends/rest.py
+++ b/src/borgstore/backends/rest.py
@@ -251,7 +251,15 @@ class StdioSession:
         response_headers = requests.structures.CaseInsensitiveDict()
         while True:
             line = self.process.stdout.readline()
-            if line in (b"\r\n", b"\n", b""):
+            if not line:
+                if self._stderr_thread is not None:
+                    self._stderr_thread.join(timeout=0.5)
+                stderr_tail = "\n".join(self._stderr_lines)
+                detail = f":\n{stderr_tail}" if stderr_tail else ""
+                raise BackendConnectionError(
+                    f"stdio server closed connection unexpectedly while reading headers{detail}"
+                )
+            if line in (b"\r\n", b"\n"):
                 break
             header_line = line.decode("iso-8859-1").strip()
             if ":" in header_line:

--- a/src/borgstore/backends/rest.py
+++ b/src/borgstore/backends/rest.py
@@ -267,7 +267,18 @@ class StdioSession:
                 response_headers[key.strip()] = value.strip()
 
         content_length = int(response_headers.get("Content-Length", "0"))
-        response_body = self.process.stdout.read(content_length) if method.upper() != "HEAD" and content_length else b""
+        response_body = b""
+        if method.upper() != "HEAD" and content_length > 0:
+            response_body = self.process.stdout.read(content_length)
+            if len(response_body) < content_length:
+                if self._stderr_thread is not None:
+                    self._stderr_thread.join(timeout=0.5)
+                stderr_tail = "\n".join(self._stderr_lines)
+                detail = f":\n{stderr_tail}" if stderr_tail else ""
+                raise BackendConnectionError(
+                    f"stdio server closed connection unexpectedly while reading response body: "
+                    f"expected {content_length} bytes, got {len(response_body)}{detail}"
+                )
 
         response = requests.Response()
         response.status_code = status_code

--- a/tests/test_rest_reconnect.py
+++ b/tests/test_rest_reconnect.py
@@ -207,3 +207,23 @@ def test_stdio_request_broken_pipe_raises_connection_error():
 
     with pytest.raises(BackendConnectionError):
         session.request("GET", "http://stdio-backend/item")
+
+
+def test_stdio_request_eof_during_headers_raises_connection_error():
+    """Unexpected EOF while reading headers is reported as a connection error."""
+    session = StdioSession(command=["true"])
+    session.process = _FakeProc(stdout_data=b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\n")
+
+    with pytest.raises(BackendConnectionError) as exc_info:
+        session.request("GET", "http://stdio-backend/item")
+    assert "reading headers" in str(exc_info.value)
+
+
+def test_stdio_request_eof_during_body_raises_connection_error():
+    """Unexpected EOF while reading body (shorter than Content-Length) is reported as a connection error."""
+    session = StdioSession(command=["true"])
+    session.process = _FakeProc(stdout_data=b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\n123")
+
+    with pytest.raises(BackendConnectionError) as exc_info:
+        session.request("GET", "http://stdio-backend/item")
+    assert "reading response body" in str(exc_info.value)

--- a/tests/test_rest_reconnect.py
+++ b/tests/test_rest_reconnect.py
@@ -1,0 +1,209 @@
+"""
+Tests for the REST backend's connection-loss recovery over stdio-over-ssh (and http).
+
+These tests do not need a real server or ssh: they exercise the with_reconnect decorator, the
+_is_connection_lost helper, ssh_cmd keepalive options and StdioSession's EOF handling in isolation.
+"""
+
+import io
+
+import pytest
+
+requests = pytest.importorskip("requests")
+
+from borgstore.backends.errors import BackendConnectionError, BackendError, ObjectNotFound, PermissionDenied
+from borgstore.backends.rest import (
+    StdioSession,
+    ssh_cmd,
+    with_reconnect,
+    _is_connection_lost,
+    SSH_ALIVE_INTERVAL,
+    SSH_ALIVE_COUNT_MAX,
+)
+
+
+@pytest.mark.parametrize(
+    "exc, expected",
+    [
+        (BackendConnectionError("gone"), True),
+        (BrokenPipeError(), True),
+        (ConnectionResetError(), True),
+        (EOFError(), True),
+        (requests.exceptions.ConnectionError(), True),
+        (requests.exceptions.Timeout(), True),
+        (requests.exceptions.ChunkedEncodingError(), True),
+        # legit results / unrelated errors, must NOT be treated as connection loss:
+        (ObjectNotFound("x"), False),
+        (PermissionDenied("x"), False),
+        (BackendError("some other backend error"), False),
+        (ValueError("nope"), False),
+    ],
+)
+def test_is_connection_lost(exc, expected):
+    assert _is_connection_lost(exc) is expected
+
+
+class FakeREST:
+    """Minimal stand-in providing exactly what with_reconnect / _reconnect touch."""
+
+    def __init__(self, reconnect_tries=3):
+        self.session = object()  # "opened" (non-None)
+        self.reconnect_tries = reconnect_tries
+        self.reconnect_wait = 0  # do not slow down the tests
+        self.reconnects = 0
+
+    def _reconnect(self):
+        self.reconnects += 1
+        self.session = object()  # fresh session
+
+
+def test_retry_succeeds_after_reconnect():
+    obj = FakeREST()
+    calls = {"n": 0}
+
+    @with_reconnect
+    def op(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise BackendConnectionError("dropped")
+        return "ok"
+
+    assert op(obj) == "ok"
+    assert obj.reconnects == 1
+    assert calls["n"] == 2
+
+
+def test_no_retry_for_non_connection_error():
+    obj = FakeREST()
+
+    @with_reconnect
+    def op(self):
+        raise ObjectNotFound("missing")
+
+    with pytest.raises(ObjectNotFound):
+        op(obj)
+    assert obj.reconnects == 0
+
+
+def test_gives_up_after_all_tries():
+    obj = FakeREST(reconnect_tries=3)
+
+    @with_reconnect
+    def op(self):
+        raise BackendConnectionError("still down")
+
+    with pytest.raises(BackendError):
+        op(obj)
+    assert obj.reconnects == 3
+
+
+def test_not_opened_does_not_reconnect():
+    obj = FakeREST()
+    obj.session = None  # not opened
+
+    @with_reconnect
+    def op(self):
+        raise BackendConnectionError("dropped")
+
+    with pytest.raises(BackendConnectionError):
+        op(obj)
+    assert obj.reconnects == 0
+
+
+def test_swallow_not_found_on_retry():
+    """delete/move: ObjectNotFound after a reconnect means the earlier attempt already did it."""
+    obj = FakeREST()
+    calls = {"n": 0}
+
+    @with_reconnect(swallow_not_found=True)
+    def op(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise BackendConnectionError("dropped")  # op may already have succeeded
+        raise ObjectNotFound("gone")  # retry: already gone -> treat as success
+
+    assert op(obj) is None
+    assert obj.reconnects == 1
+
+
+def test_object_not_found_propagates_on_first_attempt_even_when_swallowing():
+    obj = FakeREST()
+
+    @with_reconnect(swallow_not_found=True)
+    def op(self):
+        raise ObjectNotFound("gone")
+
+    with pytest.raises(ObjectNotFound):
+        op(obj)
+    assert obj.reconnects == 0
+
+
+def test_ssh_cmd_has_keepalive_by_default(monkeypatch):
+    monkeypatch.delenv("BORGSTORE_RSH", raising=False)
+    cmd = ssh_cmd("user", "host", "2222")
+    assert cmd[0] == "ssh"
+    assert f"ServerAliveInterval={SSH_ALIVE_INTERVAL}" in cmd
+    assert f"ServerAliveCountMax={SSH_ALIVE_COUNT_MAX}" in cmd
+    assert "-p" in cmd and "2222" in cmd
+    assert cmd[-1] == "user@host"
+
+
+def test_ssh_cmd_custom_rsh_is_verbatim(monkeypatch):
+    monkeypatch.setenv("BORGSTORE_RSH", "ssh -F /my/config")
+    cmd = ssh_cmd("user", "host", "22")
+    # a custom rsh is used as-is: we do not inject keepalive options.
+    assert cmd[:3] == ["ssh", "-F", "/my/config"]
+    assert not any("ServerAlive" in part for part in cmd)
+    assert cmd[-1] == "user@host"
+
+
+class _FakeStdin:
+    def __init__(self):
+        self.buffer = bytearray()
+
+    def write(self, data):
+        self.buffer.extend(data)
+
+    def flush(self):
+        pass
+
+
+class _FakeStdout:
+    def __init__(self, data=b""):
+        self._io = io.BytesIO(data)
+
+    def readline(self):
+        return self._io.readline()
+
+    def read(self, n):
+        return self._io.read(n)
+
+
+class _FakeProc:
+    def __init__(self, stdout_data=b""):
+        self.stdin = _FakeStdin()
+        self.stdout = _FakeStdout(stdout_data)
+
+
+def test_stdio_request_eof_raises_connection_error():
+    """When the server/ssh closed the pipe (readline -> b''), request() raises a connection error."""
+    session = StdioSession(command=["true"])
+    session.process = _FakeProc(stdout_data=b"")  # immediate EOF on the response
+
+    with pytest.raises(BackendConnectionError):
+        session.request("GET", "http://stdio-backend/item")
+
+
+def test_stdio_request_broken_pipe_raises_connection_error():
+    """A broken pipe while sending the request is reported as a connection error."""
+    session = StdioSession(command=["true"])
+    proc = _FakeProc()
+
+    def boom(_data):
+        raise BrokenPipeError()
+
+    proc.stdin.write = boom
+    session.process = proc
+
+    with pytest.raises(BackendConnectionError):
+        session.request("GET", "http://stdio-backend/item")


### PR DESCRIPTION
Follow-up to #189 (the SFTP fix): the same "hang forever on a dead connection" problem exists for `rest://` backends, which tunnel HTTP over stdio over ssh.

## Problem

In `StdioSession.request`, the response is read from the ssh subprocess with `process.stdout.readline()` / `read(content_length)` — **no timeout**. When the network dies (laptop suspended, etc.), `ssh` stays alive waiting on the dead peer, so the read blocks **forever** — the #167 hang, one layer up. The send side can wedge too once ssh's stdin buffer fills.

## Fix (mirrors the SFTP fix)

**Don't hang.** `ssh_cmd()` now adds keepalive (`-o ServerAliveInterval` / `-o ServerAliveCountMax`) to the ssh command we build, so ssh notices a dead peer and exits; that closes the stdio pipe and our read returns EOF instead of blocking. A custom `BORGSTORE_RSH` is left **verbatim** — the user controls its options.

**Reconnect and retry.** `StdioSession.request()` now converts a broken pipe (while sending) and an unexpected EOF (while receiving) into a new `BackendConnectionError`. A `with_reconnect` decorator wraps the REST operations: on a connection loss it restarts the session — the ssh + `borgstore-server-rest` process (stdio mode) or a fresh `requests.Session` (plain http mode) — and retries, up to `reconnect_tries` times, giving up with a `BackendError` otherwise.

The remote server holds **no cross-request state** (a fresh handler per request against the `FILE:` backend), so replaying the failed request is safe. `delete`/`move` use `swallow_not_found=True` (same at-least-once reasoning as the SFTP PR: an `ObjectNotFound` on the *retry* path means an earlier attempt already succeeded). `list()` is a generator, so its network access is pulled into a decorated `_list_entries()` helper.

## Tests

- New `tests/test_rest_reconnect.py` (21 tests, no server/ssh needed): error classifier, retry-then-succeed, no-retry-on-`ObjectNotFound`, give-up-after-N-tries, no-reconnect-when-closed, `swallow_not_found` behavior, `ssh_cmd` keepalive (present by default, absent/verbatim for `BORGSTORE_RSH`), and `StdioSession.request` raising `BackendConnectionError` on EOF and broken pipe.
- `tests/test_server_rest.py` + `tests/test_backends.py`: no new failures (two pre-existing `atime > 0` failures are environment-specific — macOS noatime — and fail identically on master).
- `black` + `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)