### PR TITLE
docs: build docs also if borgstore is not installed, fixes #204

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,12 @@ New features:
   sftp and s3 internally create a bytes object first, because paramiko / boto3
   do not accept a memoryview.
 
+Fixes:
+
+- docs: build the docs also if borgstore is not installed, #204.
+  conf.py now falls back to the setuptools_scm generated src/borgstore/_version.py
+  and, if that is not there either, to an empty version.
+
 
 Version 0.5.5 (2026-07-10)
 --------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,12 +6,32 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-from importlib.metadata import version as pkg_version
+import os
+import sys
+from importlib.metadata import PackageNotFoundError, version as pkg_version
+
+
+def get_release():
+    """Determine the borgstore version, without requiring borgstore to be installed."""
+    try:
+        return pkg_version("borgstore")
+    except PackageNotFoundError:
+        pass
+    # not installed - maybe we are in a source tree where setuptools_scm already generated _version.py.
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+    try:
+        from borgstore._version import version  # noqa
+
+        return version
+    except ImportError:
+        # neither installed nor built - the docs do not really need the version, so just go on without it.
+        return ""
+
 
 project = "BorgStore"
 copyright = "2026, Thomas Waldmann"
 author = "Thomas Waldmann"
-release = pkg_version("borgstore")
+release = get_release()
 version = ".".join(release.split(".")[:2])
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
`docs/conf.py` determined the version via `importlib.metadata.version("borgstore")`,
which raises `PackageNotFoundError` if borgstore is not installed. Sphinx then aborts
with a "Configuration error", so `make html` fails in an unpacked source tarball
(as hit by a distro packager in #204).

`get_release()` now tries, in order:

1. the installed package metadata,
2. the setuptools_scm generated `src/borgstore/_version.py` (source tree that was built),
3. an empty version - the docs do not really need it to build.

Verified all three paths resolve as expected (installed / `_version.py` fallback / empty),
and the patch was confirmed working by the reporter in #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)