### PR TITLE
add support for Python 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
             - os: ubuntu-latest
               python-version: '3.14'
               toxenv: py314
+            - os: ubuntu-latest
+              python-version: '3.15-dev'
+              toxenv: py315
+              # 3.15 is not released yet, so do not fail the whole matrix if it
+              # (or a dependency not having wheels for it yet) breaks.
+              allow-failure: true
             - os: macos-latest
               python-version: '3.12'
               toxenv: py312

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,12 @@ Fixes:
   conf.py now falls back to the setuptools_scm generated src/borgstore/_version.py
   and, if that is not there either, to an empty version.
 
+Other changes:
+
+- add support for Python 3.15: classifier, tox py315 env and a CI job running
+  the test suite on 3.15-dev. As 3.15 is not released yet, that CI job is
+  allowed to fail.
+
 
 Version 0.5.5 (2026-07-10)
 --------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # tox configuration - if you change anything here, run this to verify: tox --recreate
 
 [tox]
-envlist = py{311,312,313,314},flake8,mypy
+envlist = py{311,312,313,314,315},flake8,mypy
 
 [testenv]
 deps =


### PR DESCRIPTION
- pyproject: add the 3.15 classifier
- tox: add py315 to the envlist
- CI: add a job running the test suite on 3.15-dev (ubuntu-latest)

3.15 is not released yet and the CI matrix uses fail-fast, so the new job is
marked allow-failure for now (also guards against deps that do not have 3.15
wheels yet). That line should be removed once 3.15 is final.

Source-wise nothing needed changing: the only version-conditional code is the
shutil.rmtree onexc/onerror switch in posixfs.py (already on the >=3.12 branch)
and no stdlib module used by borgstore is removed in 3.15.

Not tested locally (no 3.15 interpreter here) - CI on 3.15-dev is the test.