### PR TITLE
CI: harden the workflows (zizmor) and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Keep the GitHub Actions we use and our Python requirements up to date.
+#
+# The cooldown periods keep us off freshly released versions for a while - if
+# an action or package gets yanked or hotfixed shortly after a release, we
+# never see it.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      # default-days also covers patch releases and actions not using semver.
+      default-days: 14
+      semver-minor-days: 30
+      semver-major-days: 90
+    groups:
+      actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "pip"
+    directory: "/requirements.d"
+    ignore:
+    # black is also pinned in .github/workflows/black.yaml, which dependabot
+    # can not update - bumping only requirements.d/codestyle.txt would make the
+    # two disagree, so we do these bumps by hand.
+    - dependency-name: "black"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      # default-days also covers patch releases and packages not using semver.
+      default-days: 14
+      semver-minor-days: 30
+      semver-major-days: 90
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -5,6 +5,10 @@ name: Lint
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -12,7 +16,9 @@ jobs:
   lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
-      - uses: psf/black@stable
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e  # 26.5.1
         with:
             version: "~= 26.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ on:
     - 'requirements.d/*'
     - '!docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci_job:
 
@@ -70,10 +74,11 @@ jobs:
     continue-on-error: ${{ matrix.allow-failure || false }}
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         # just fetching 1 commit is not enough for setuptools-scm, so we fetch all
         fetch-depth: 0
+        persist-credentials: false
     - name: Install Linux packages
       if: runner.os == 'Linux'
       run: |
@@ -199,7 +204,7 @@ jobs:
         echo "BORGSTORE_TEST_REST1_URL=http://testuser:testpass@localhost/repos/repo1/" >> $GITHUB_ENV
         echo "BORGSTORE_TEST_REST2_URL=http://testuser:testpass@localhost/repos/repo2/" >> $GITHUB_ENV
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python requirements
@@ -216,7 +221,8 @@ jobs:
       if: runner.os == 'macOS'
       run: pip install -ve ".[rest,rclone,blake3]"
     - name: run tox envs
-      run: tox -e ${{ matrix.toxenv }}
+      # the toxenv comes from the job-level TOXENV env var, see above.
+      run: tox
     - name: Display diagnostics on failure
       if: failure() && runner.os == 'Linux'
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
         # Just fetching one commit is not enough for setuptools-scm, so we fetch all.
         fetch-depth: 0
         fetch-tags: true
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0


### PR DESCRIPTION
Ran [zizmor](https://docs.zizmor.sh/) 1.30 over `.github/workflows/` and fixed everything it reported, plus a dependabot config modelled on the one in borg.

## What zizmor found

| audit | severity | where |
|---|---|---|
| `unpinned-uses` | high (4x) | `actions/checkout@v7`, `actions/setup-python@v6`, `psf/black@stable` |
| `artipacked` | medium / low (3x) | every `actions/checkout` step |
| `template-injection` | (auditor) | `tox -e ${{ matrix.toxenv }}` in `ci.yml` |
| `concurrency-limits` | (auditor) | `ci.yml`, `black.yaml` |

## What this changes

* **Hash-pin the actions**, version in a trailing comment, the way `release.yml` already does it. The one that actually mattered is `psf/black@stable` — `stable` is a *branch* of a third-party action. `setup-python` goes v6 → v7 on the way; v7 only drops the `pip-install` input, which we do not use, and borg already runs v7 on the same OS set.
* **`persist-credentials: false`** on all checkouts. Nothing here pushes, so the token has no reason to sit in the workspace `.git/config`. In `release.yml` that is the medium finding: the token was in the workspace while the sdist artifact got uploaded. That job talks to GitHub via `GH_TOKEN`, not via git, so it does not care.
* **`run: tox`** instead of `tox -e ${{ matrix.toxenv }}`. Not exploitable — the matrix values are literals in the workflow — but the job already exports `TOXENV`, so the expansion was redundant anyway.
* **A `concurrency:` group** for CI and Lint, same expression as borg. Pushing twice to a PR branch now cancels the older run instead of stacking up. Not a security thing, just runner time.
* **`.github/dependabot.yml`**, same shape as borg's: weekly grouped updates for the actions (they need something to bump them now that they are hashes) and for `requirements.d`, with a cooldown so a version that gets yanked right after release does not reach us. `black` is excluded because its version lives in two places (`requirements.d/codestyle.txt` and the `psf/black` step) and dependabot only sees one of them.

`zizmor --offline .github/workflows/` is clean now. With `--persona=auditor` three things remain, deliberately:

* `concurrency-limits` on `release.yml` — that one is tag-triggered, cancelling a release build in flight is not what we want.
* `anonymous-definition` on the `lint` and `ci_job` jobs — adding a `name:` renames the check runs, which would break any required-status-check configuration. Left alone.

No functional change to what CI runs.