### PR TITLE
posixfs: remove the partially written temp file if writing it fails

### DIFF
--- a/src/borgstore/backends/posixfs.py
+++ b/src/borgstore/backends/posixfs.py
@@ -223,13 +223,26 @@ class PosixFS(BackendBase):
             raise ObjectNotFound(name) from None
 
     def _write_to_tempfile(self, path, value, suffix=TMP_SUFFIX, do_fsync=False):
-        with tempfile.NamedTemporaryFile(suffix=suffix, dir=path, delete=False) as f:
-            f.write(value)
-            if do_fsync:
-                f.flush()
-                os.fsync(f.fileno())
-            tmp_path = Path(f.name)
-        return tmp_path
+        """Write value to a new, uniquely named temp file in directory path, return the temp file's Path.
+
+        If writing fails (e.g. disk full, I/O error), the partially written temp file is removed
+        before the exception is re-raised, so it does not linger in the store: it would be invisible
+        to .list (TMP_SUFFIX), but it would occupy space (and be counted by the quota scan).
+        """
+        tmp = tempfile.NamedTemporaryFile(suffix=suffix, dir=path, delete=False)
+        try:
+            with tmp as f:  # closes the file, flushing any buffered data (that can fail, too)
+                f.write(value)
+                if do_fsync:
+                    f.flush()
+                    os.fsync(f.fileno())
+        except BaseException:
+            try:
+                os.unlink(tmp.name)
+            except OSError:
+                pass  # the original exception is more interesting
+            raise
+        return Path(tmp.name)
 
     def store(self, name, value):
         if not self.opened:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -3,6 +3,7 @@ Generic tests for the backend implementations.
 """
 
 import array
+import errno
 import hashlib
 import os
 import sys
@@ -787,6 +788,33 @@ def test_posixfs_missing_parent_dirs(tmp_path):
         be.store("key", b"value")
     finally:
         be.close()
+
+
+@pytest.mark.skipif(is_win32, reason="uses resource.RLIMIT_FSIZE, which is not available on windows")
+@pytest.mark.parametrize("size", [1000, 1000000], ids=["fails-at-close", "fails-in-write"])
+def test_posixfs_failed_write_leaves_no_tmpfile(posixfs_backend_created, size):
+    # a file size limit makes writes beyond it fail with EFBIG (python ignores SIGXFSZ), so we get a real,
+    # partially written temp file, like with a full disk. a small value fits into the file object's buffer
+    # and only fails when it is flushed at close time, a big value already fails in write.
+    import resource
+
+    backend = posixfs_backend_created
+    soft, hard = resource.getrlimit(resource.RLIMIT_FSIZE)
+    with backend:
+        resource.setrlimit(resource.RLIMIT_FSIZE, (512, hard))
+        try:
+            with pytest.raises(OSError) as exc_info:
+                backend.store("key", b"x" * size)
+        finally:
+            resource.setrlimit(resource.RLIMIT_FSIZE, (soft, hard))
+        assert exc_info.value.errno == errno.EFBIG
+        # the failed store must not leave anything behind, especially not a (partial) temp file:
+        assert list(backend.base_path.iterdir()) == []
+        assert not backend.info("key").exists
+        # and the backend must still work normally:
+        backend.store("key", b"x" * size)
+        assert backend.load("key") == b"x" * size
+        assert list_names(backend, ROOTNS) == ["key"]
 
 
 def test_hash(tested_backends, request):


### PR DESCRIPTION
If writing the temp file fails (e.g. disk full, I/O error), `_write_to_tempfile` left the partially written `*.tmp` file behind. Such files are invisible to `list()` (`TMP_SUFFIX`), nothing ever removes them, they occupy space (making a full-disk situation worse with every failed `store()`) and they get counted by the quota scan.

Now the temp file is unlinked before the exception is re-raised. This covers failures in `write`, in `fsync` and in the flush done when closing the file. Both `store()` and the quota persistence use this helper.

The test provokes a real `EFBIG` write error via `RLIMIT_FSIZE` (Python ignores `SIGXFSZ`) instead of mocking: once for a value that fails inside `write`, once for a small one that is buffered and only fails when flushed at close time. It is skipped on Windows (no `resource` module).

Note: the sftp backend has the same pattern (a failed upload leaves its temp file behind), not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
