### PR TITLE
posixfs: fix lost quota updates when sessions persist concurrently

### DIFF
--- a/src/borgstore/backends/posixfs.py
+++ b/src/borgstore/backends/posixfs.py
@@ -387,6 +387,30 @@ class PosixFS(BackendBase):
                     total += self._quota_scan(entry.path, skips)
         return total
 
+    def _quota_lock(self, fd):
+        """Exclusively lock the quota file (open as fd), blocking until the lock is acquired.
+
+        No-op on platforms without flock (Windows): there, concurrent sessions are not supported.
+        """
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+
+    def _quota_unlock(self, fd):
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+
+    @staticmethod
+    def _quota_file_is_current(fd, quota_path):
+        """Check whether the (locked) open file fd still is the quota file at quota_path.
+
+        Another session may have replaced the quota file (by a new file / inode) while we were
+        waiting for the lock: then we hold a lock on the old, unlinked file and must not use it.
+        """
+        try:
+            return os.path.samestat(os.fstat(fd), os.stat(quota_path))
+        except FileNotFoundError:
+            return False  # the quota file was deleted meanwhile
+
     def _quota_persist(self, delta):
         """Persist quota usage to the on-disk quota file.
 
@@ -394,55 +418,54 @@ class PosixFS(BackendBase):
         to the current on-disk value under an exclusive file lock.  This way,
         updates from other sessions are preserved.
 
-        If the quota file does not exist or contains an invalid value, a
-        filesystem scan is performed to determine the actual usage.
+        If the quota file does not exist yet or contains an invalid value, a
+        filesystem scan is performed (under the lock) to determine the actual usage.
 
-        The quota file itself is used as the lock file (opened and locked
-        with flock) so no separate lock file is needed.
+        The quota file itself is used as the lock file (opened and locked with
+        flock) so no separate lock file is needed. As an update replaces the
+        quota file by a new one (atomic rename), a session that opened the file
+        before such a replacement acquires the lock on a stale, unlinked file:
+        it detects that and retries with the current quota file.
         """
         quota_path = self._quota_path()
-        try:
-            fd = os.open(str(quota_path), os.O_RDONLY)
-        except FileNotFoundError:
-            # quota file missing, scan filesystem to determine usage
-            skips = {os.path.abspath(quota_path)}
-            quota_use = self._quota_scan(self.base_path, skips)
-            quota_path.write_text(str(quota_use))
-            self._quota_use_persisted = quota_use
-            self._quota_use = quota_use
-            self._quota_last_persist_time = time.monotonic()
-            return
-        try:
-            if fcntl is not None:
-                fcntl.flock(fd, fcntl.LOCK_EX)
-            # read current on-disk value (may have been updated by another session)
+        while True:
+            # if there is no quota file yet, create an empty one: we need it as the lock file
+            # and its (invalid) content triggers the filesystem scan below.
+            fd = os.open(str(quota_path), os.O_RDONLY | os.O_CREAT, 0o666)
             try:
-                on_disk = int(os.read(fd, 100))
-            except ValueError:
-                # invalid content, scan filesystem to determine usage
-                skips = {os.path.abspath(quota_path)}
-                on_disk = self._quota_scan(self.base_path, skips)
-                delta = 0  # scan already gives the true value
-            if is_win32:
-                # Close the file before replacing to avoid AccessDenied on Windows.
-                os.close(fd)
-                fd = -1
-            new_value = max(on_disk + delta, 0)
-            quota_content = str(new_value).encode()
-            tmp_path = self._write_to_tempfile(quota_path.parent, quota_content, do_fsync=True)
-            try:
-                tmp_path.replace(quota_path)  # atomic update
-            except OSError:
-                tmp_path.unlink()
-                raise
-            self._quota_use_persisted = new_value
-            self._quota_use = new_value  # re-sync with on-disk truth
-            self._quota_last_persist_time = time.monotonic()
-        finally:
-            if fcntl is not None:
-                fcntl.flock(fd, fcntl.LOCK_UN)
-            if fd >= 0:
-                os.close(fd)
+                self._quota_lock(fd)
+                if not self._quota_file_is_current(fd, quota_path):
+                    continue  # unlock and close the stale file (see finally), retry with the current one
+                # read current on-disk value (may have been updated by another session)
+                try:
+                    on_disk = int(os.read(fd, 100))
+                except ValueError:
+                    # no or invalid content, scan filesystem to determine usage
+                    skips = {os.path.abspath(quota_path)}
+                    on_disk = self._quota_scan(self.base_path, skips)
+                    delta = 0  # scan already gives the true value
+                if is_win32:
+                    # Close the file before replacing to avoid AccessDenied on Windows.
+                    os.close(fd)
+                    fd = -1
+                new_value = max(on_disk + delta, 0)
+                quota_content = str(new_value).encode()
+                tmp_path = self._write_to_tempfile(quota_path.parent, quota_content, do_fsync=True)
+                try:
+                    tmp_path.replace(quota_path)  # atomic update
+                except OSError:
+                    tmp_path.unlink()
+                    raise
+                self._quota_use_persisted = new_value
+                self._quota_use = new_value  # re-sync with on-disk truth
+                self._quota_last_persist_time = time.monotonic()
+                return
+            finally:
+                if fd >= 0:
+                    try:
+                        self._quota_unlock(fd)
+                    finally:
+                        os.close(fd)
 
     def _quota_update(self, delta, force=False):
         """Update quota usage by delta and persist if the change is significant or enough time has elapsed."""

--- a/tests/test_posixfs_quota.py
+++ b/tests/test_posixfs_quota.py
@@ -1,6 +1,8 @@
 """Tests for PosixFS quota support."""
 
 import array
+import sys
+import threading
 import time
 
 import pytest
@@ -8,6 +10,8 @@ import pytest
 from borgstore.backends.posixfs import PosixFS
 from borgstore.backends.errors import QuotaExceeded
 from borgstore.constants import QUOTA_STORE_NAME, QUOTA_PERSIST_DELTA, QUOTA_PERSIST_INTERVAL
+
+is_win32 = sys.platform == "win32"
 
 
 @pytest.fixture()
@@ -480,3 +484,80 @@ class TestQuotaConcurrency:
         quota_path = store_path / QUOTA_STORE_NAME
         on_disk = int(quota_path.read_text())
         assert on_disk == 600  # 200 + 300 + 100
+
+    @pytest.mark.skipif(is_win32, reason="needs flock (no locking on windows)")
+    def test_lock_on_replaced_quota_file_is_stale(self, tmp_path):
+        """A session that waited for the lock must not clobber the update of the session it waited for.
+
+        Each update replaces the quota file by a new one (atomic rename), so the lock a session gets on the
+        file it opened before that replacement is on a stale file: it must retry with the current quota file.
+        """
+        store_path = tmp_path / "store"
+        PosixFS(store_path, quota=10**6).create()
+        a = PosixFS(store_path, quota=10**6)
+        b = PosixFS(store_path, quota=10**6)
+        a.open()
+        b.open()
+        quota_path = store_path / QUOTA_STORE_NAME
+        assert int(quota_path.read_text()) == 0
+
+        a_locked = threading.Event()  # a holds the lock
+        b_waiting = threading.Event()  # b has opened the quota file and is about to block on the lock
+        real_a_lock, real_a_write, real_b_lock = a._quota_lock, a._write_to_tempfile, b._quota_lock
+
+        def a_lock(fd):
+            real_a_lock(fd)
+            a_locked.set()
+
+        def a_write(*args, **kwargs):
+            # keep the lock until b is queued on it, only then replace the quota file
+            assert b_waiting.wait(10)
+            return real_a_write(*args, **kwargs)
+
+        def b_lock(fd):
+            b_waiting.set()
+            real_b_lock(fd)
+
+        a._quota_lock, a._write_to_tempfile, b._quota_lock = a_lock, a_write, b_lock
+        thread_a = threading.Thread(target=a._quota_persist, args=(500,))
+        thread_b = threading.Thread(target=b._quota_persist, args=(300,))
+        thread_a.start()
+        assert a_locked.wait(10)
+        thread_b.start()
+        thread_a.join(10)
+        thread_b.join(10)
+        assert not thread_a.is_alive() and not thread_b.is_alive()
+        # b read the stale value 0 from the replaced file and would have written 300 without the retry:
+        assert int(quota_path.read_text()) == 800
+        assert a._quota_use == 500
+        assert b._quota_use == 800  # re-synced with the on-disk truth
+        a.close()
+        b.close()
+
+    @pytest.mark.skipif(is_win32, reason="needs flock (no locking on windows)")
+    def test_concurrent_persists_lose_no_updates(self, tmp_path):
+        """Many sessions storing and persisting concurrently: every update must make it into the on-disk value."""
+        store_path = tmp_path / "store"
+        quota = 10**9
+        PosixFS(store_path, quota=quota).create()
+        sessions, stores, size = 4, 50, 100
+        errors = []
+
+        def session(idx):
+            try:
+                be = PosixFS(store_path, quota=quota)
+                be.open()
+                for i in range(stores):
+                    be.store(f"obj-{idx}-{i}", b"x" * size)
+                    be._quota_update(0, force=True)
+                be.close()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=session, args=(idx,)) for idx in range(sessions)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert not errors
+        assert int((store_path / QUOTA_STORE_NAME).read_text()) == sessions * stores * size


### PR DESCRIPTION
`_quota_persist` uses the quota file as the flock lock file, but each update replaces that file by a new one (atomic rename). A session that opened the quota file before such a replacement and then waited for the lock got the lock on the old, unlinked file, read the stale value from it and wrote `stale + own delta` over the current file: the update of the session it had waited for was lost. Even a session with delta 0 (e.g. a read-only one closing) reset the value that way.

Measured with the unfixed code:

| scenario | expected | persisted |
|---|---|---|
| A persists +500, B persists +300 (B queued on the lock while A holds it) | 800 | 300 |
| A persists +500, read-only B persists +0 | 500 | 0 |
| 4 sessions, 300 stores of 100 bytes each, persisting after every store | 120000 | ~46500 |

The fix keeps the design (quota file = lock file, atomic-rename updates): after acquiring the lock, a session checks that the locked file still is the current quota file (same device and inode, `os.path.samestat`) and otherwise unlocks, closes and retries with the current file. The quota file is created (empty) via `O_CREAT` if it does not exist yet, so the initial filesystem scan now runs under the lock, too, and its result is written atomically like any other update (before, that was an unlocked, non-atomic write). The lock/unlock calls became small methods so tests can hook them. Windows behaviour is unchanged (it never had locking).

Tests:
- a deterministic interleaving: session A holds the lock until B has opened the file and is queued on it, then A replaces the file; B must retry and produce 800 instead of 300.
- a stress test: 4 threads, each with its own backend instance, storing and force-persisting 50 times; the final value must be the exact sum (flock contention between threads works like between processes). Without the fix it persists ~8000 of 20000.

Not changed (known limitations of the quota design from borgbackup/borgstore#19): a filesystem rescan counts objects that other open sessions have written but not persisted yet (those get counted twice when they persist later), and the REST server shares one backend instance across request threads without a lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
